### PR TITLE
Fix resize warnings

### DIFF
--- a/src/PanelWindow.vala
+++ b/src/PanelWindow.vala
@@ -66,9 +66,6 @@ public class Wingpanel.PanelWindow : Gtk.Window {
         panel.realize.connect (on_realize);
 
         this.add (panel);
-
-        this.set_size_request (monitor_width, -1);
-        this.resize (monitor_width, 1);
     }
 
     private bool animation_step () {


### PR DESCRIPTION
Fixes `gtk_window_resize` warnings. There is no point in resizing the window if the `monitor_width` wasn't assigned yet.