### PR TITLE
Remove unnecessary init () call

### DIFF
--- a/src/Wingpanel.vala
+++ b/src/Wingpanel.vala
@@ -19,7 +19,6 @@
 
 namespace Wingpanel {
     public static int main (string[] args) {
-        Gtk.init (ref args);
         var app = WingpanelApp.instance;
 
         return app.run (args);


### PR DESCRIPTION
`Gtk.init` call isn't needed here since the application class subclasses`Granite.Application` which is also subclassing `Gtk.Application` which takes care of initializing Gtk.