### PR TITLE
Fix segfaults and deregister warnings

### DIFF
--- a/lib/IndicatorManager.vala
+++ b/lib/IndicatorManager.vala
@@ -316,7 +316,7 @@ public class Wingpanel.IndicatorManager : GLib.Object {
     public void register_indicator (string path, Wingpanel.Indicator indicator) {
         debug ("%s registered", indicator.code_name);
 
-        var deregister_map = new Gee.HashMap<string,Wingpanel.Indicator> ();
+        var deregister_map = new Gee.HashMap<string, Wingpanel.Indicator> ();
         indicators.@foreach ((entry) => {
             var val = entry.value;
             if (val.code_name == indicator.code_name) {

--- a/lib/IndicatorManager.vala
+++ b/lib/IndicatorManager.vala
@@ -180,7 +180,7 @@ public class Wingpanel.IndicatorManager : GLib.Object {
         }
 
         RegisterPluginFunction register_plugin = (RegisterPluginFunction)function;
-        Indicator? indicator = register_plugin (module, server_type);
+        Wingpanel.Indicator? indicator = register_plugin (module, server_type);
 
         if (indicator == null) {
             debug ("Unknown plugin type for %s or indicator is hidden on this server!", path);


### PR DESCRIPTION
A classic example of removing something from the list in the iteration loop was causing segfaults because of accessing memory that's non existent. I've also fixed the problem that the indicators were tried to be deregistered even if they weren't registered, resulting in warnings like `[03:09:54.929258 Critical] wingpanel_indicator_manager_deregister_indicator: assertion 'indicator != NULL' failed`. This should partially fix #21. The wingpanel will still restart because there are some indicators that don't put their `Wingpanel.Indicator` in any namespace and that also results in a crash e.g: notifications-indicator. A really easy way of testing that is just duplicating the .so file in the Wingpanel's plugin directory.