### PR TITLE
Cycle indicators

### DIFF
--- a/src/PanelWindow.vala
+++ b/src/PanelWindow.vala
@@ -65,6 +65,12 @@ public class Wingpanel.PanelWindow : Gtk.Window {
         panel = new Widgets.Panel (popover_manager);
         panel.realize.connect (on_realize);
 
+        var cycle_action = new SimpleAction ("cycle", null);
+        cycle_action.activate.connect (panel.cycle);
+
+        app.add_action (cycle_action);
+        app.add_accelerator ("<Control>Tab", "app.cycle", null);
+
         this.add (panel);
     }
 

--- a/src/PanelWindow.vala
+++ b/src/PanelWindow.vala
@@ -66,10 +66,17 @@ public class Wingpanel.PanelWindow : Gtk.Window {
         panel.realize.connect (on_realize);
 
         var cycle_action = new SimpleAction ("cycle", null);
-        cycle_action.activate.connect (panel.cycle);
+        cycle_action.activate.connect (() => panel.cycle (true));
 
         app.add_action (cycle_action);
         app.add_accelerator ("<Control>Tab", "app.cycle", null);
+
+
+        var cycle_back_action = new SimpleAction ("cycle-back", null);
+        cycle_back_action.activate.connect (() => panel.cycle (false));
+
+        app.add_action (cycle_back_action);
+        app.add_accelerator ("<Control><Shift>Tab", "app.cycle-back", null);
 
         this.add (panel);
     }

--- a/src/PanelWindow.vala
+++ b/src/PanelWindow.vala
@@ -71,7 +71,6 @@ public class Wingpanel.PanelWindow : Gtk.Window {
         app.add_action (cycle_action);
         app.add_accelerator ("<Control>Tab", "app.cycle", null);
 
-
         var cycle_back_action = new SimpleAction ("cycle-back", null);
         cycle_back_action.activate.connect (() => panel.cycle (false));
 

--- a/src/Widgets/Panel.vala
+++ b/src/Widgets/Panel.vala
@@ -63,13 +63,19 @@ public class Wingpanel.Widgets.Panel : Gtk.Box {
         Services.BackgroundManager.get_default ().background_state_changed.connect (update_background);
     }
 
-    public void cycle () {
+    public void cycle (bool forward) {
         var current = popover_manager.current_indicator;
         if (current == null) {
             return;
         }
 
-        var sibling = get_next_sibling (current);
+        IndicatorEntry? sibling;
+        if (forward) {
+            sibling = get_next_sibling (current);
+        } else {
+            sibling = get_previous_sibling (current);
+        }
+
         if (sibling != null) {
             popover_manager.current_indicator = sibling;
         }
@@ -120,6 +126,60 @@ public class Wingpanel.Widgets.Panel : Gtk.Box {
                     var left_children = left_menubar.get_children ();
                     if (left_children.length () > 0) {
                         sibling = left_children.nth_data (0) as IndicatorEntry;
+                    }
+                }
+
+                break;
+        }
+
+        return sibling;
+    }
+
+    private IndicatorEntry? get_previous_sibling (IndicatorEntry current) {
+        IndicatorEntry? sibling = null;
+
+        switch (current.base_indicator.code_name) {
+            case Indicator.APP_LAUNCHER:
+                var children = left_menubar.get_children ();
+                int index = children.index (current);
+                if (index == -1) {
+                    break;
+                } else if (index != 0) { // Has more than one indicator in the left menubar
+                    sibling = children.nth_data (index - 1) as IndicatorEntry;
+                } else { // No more indicators on the left
+                    var right_children = right_menubar.get_children ();
+                    if (right_children.length () > 0) {
+                        sibling = right_children.last ().data as IndicatorEntry;
+                    }
+                }
+
+                break;
+            case Indicator.DATETIME:
+                var children = center_menubar.get_children ();
+                int index = children.index (current);
+                if (index == -1) {
+                    break;
+                } else if (index != 0) { // Has more than one indicator in the center menubar
+                    sibling = children.nth_data (index - 1) as IndicatorEntry;
+                } else { // No more indicators on the center
+                    var left_children = left_menubar.get_children ();
+                    if (left_children.length () > 0) {
+                        sibling = left_children.last ().data as IndicatorEntry;
+                    }
+                }
+
+                break;
+            default:
+                var children = right_menubar.get_children ();
+                int index = children.index (current);
+                if (index == -1) {
+                    break;
+                } else if (index != 0) { // Has more than one indicator in the right menubar
+                    sibling = children.nth_data (index - 1) as IndicatorEntry;
+                } else { // No more indicators on the right
+                    var center_children = center_menubar.get_children ();
+                    if (center_children.length () > 0) {
+                        sibling = center_children.last ().data as IndicatorEntry;
                     }
                 }
 

--- a/src/Widgets/Panel.vala
+++ b/src/Widgets/Panel.vala
@@ -63,6 +63,72 @@ public class Wingpanel.Widgets.Panel : Gtk.Box {
         Services.BackgroundManager.get_default ().background_state_changed.connect (update_background);
     }
 
+    public void cycle () {
+        var current = popover_manager.current_indicator;
+        if (current == null) {
+            return;
+        }
+
+        var sibling = get_next_sibling (current);
+        if (sibling != null) {
+            popover_manager.current_indicator = sibling;
+        }
+    }
+
+    private IndicatorEntry? get_next_sibling (IndicatorEntry current) {
+        IndicatorEntry? sibling = null;
+
+        switch (current.base_indicator.code_name) {
+            case Indicator.APP_LAUNCHER:
+                var children = left_menubar.get_children ();
+                int index = children.index (current);
+                if (index == -1) {
+                    break;
+                } else if (index < children.length () - 1) { // Has more than one indicator in the left menubar
+                    sibling = children.nth_data (index + 1) as IndicatorEntry;
+                } else { // No more indicators on the left
+                    var center_children = center_menubar.get_children ();
+                    if (center_children.length () > 0) {
+                        sibling = center_children.nth_data (0) as IndicatorEntry;
+                    }                    
+                }
+
+                break;
+            case Indicator.DATETIME:
+                var children = center_menubar.get_children ();
+                int index = children.index (current);
+                if (index == -1) {
+                    break;
+                } else if (index < children.length () - 1) { // Has more than one indicator in the center menubar
+                    sibling = children.nth_data (index + 1) as IndicatorEntry;
+                } else { // No more indicators on the center
+                    var right_children = right_menubar.get_children ();
+                    if (right_children.length () > 0) {
+                        sibling = right_children.nth_data (0) as IndicatorEntry;
+                    }                    
+                }
+
+                break;
+            default:
+                var children = right_menubar.get_children ();
+                int index = children.index (current);
+                if (index == -1) {
+                    break;
+                } else if (index < children.length () - 1) { // Has more than one indicator in the right menubar
+                    sibling = children.nth_data (index + 1) as IndicatorEntry;
+                } else { // No more indicators on the right
+                    var left_children = left_menubar.get_children ();
+                    if (left_children.length () > 0) {
+                        sibling = left_children.nth_data (0) as IndicatorEntry;
+                    }                    
+                }
+
+                break;
+        }
+
+        return sibling;     
+    }
+
     private void add_indicator (Indicator indicator) {
         var indicator_entry = new IndicatorEntry (indicator, popover_manager);
 

--- a/src/Widgets/Panel.vala
+++ b/src/Widgets/Panel.vala
@@ -95,7 +95,7 @@ public class Wingpanel.Widgets.Panel : Gtk.Box {
                 } else { // No more indicators on the left
                     var center_children = center_menubar.get_children ();
                     if (center_children.length () > 0) {
-                        sibling = center_children.nth_data (0) as IndicatorEntry;
+                        sibling = center_children.first ().data as IndicatorEntry;
                     }
                 }
 
@@ -110,7 +110,7 @@ public class Wingpanel.Widgets.Panel : Gtk.Box {
                 } else { // No more indicators on the center
                     var right_children = right_menubar.get_children ();
                     if (right_children.length () > 0) {
-                        sibling = right_children.nth_data (0) as IndicatorEntry;
+                        sibling = right_children.first ().data as IndicatorEntry;
                     }
                 }
 
@@ -125,7 +125,7 @@ public class Wingpanel.Widgets.Panel : Gtk.Box {
                 } else { // No more indicators on the right
                     var left_children = left_menubar.get_children ();
                     if (left_children.length () > 0) {
-                        sibling = left_children.nth_data (0) as IndicatorEntry;
+                        sibling = left_children.first ().data as IndicatorEntry;
                     }
                 }
 
@@ -144,7 +144,7 @@ public class Wingpanel.Widgets.Panel : Gtk.Box {
                 int index = children.index (current);
                 if (index == -1) {
                     break;
-                } else if (index != 0) { // Has more than one indicator in the left menubar
+                } else if (index != 0) { // Is not the first indicator in the left menubar
                     sibling = children.nth_data (index - 1) as IndicatorEntry;
                 } else { // No more indicators on the left
                     var right_children = right_menubar.get_children ();
@@ -159,7 +159,7 @@ public class Wingpanel.Widgets.Panel : Gtk.Box {
                 int index = children.index (current);
                 if (index == -1) {
                     break;
-                } else if (index != 0) { // Has more than one indicator in the center menubar
+                } else if (index != 0) { // Is not the first indicator in the center menubar
                     sibling = children.nth_data (index - 1) as IndicatorEntry;
                 } else { // No more indicators on the center
                     var left_children = left_menubar.get_children ();
@@ -174,7 +174,7 @@ public class Wingpanel.Widgets.Panel : Gtk.Box {
                 int index = children.index (current);
                 if (index == -1) {
                     break;
-                } else if (index != 0) { // Has more than one indicator in the right menubar
+                } else if (index != 0) { // Is not the first indicator in the right menubar
                     sibling = children.nth_data (index - 1) as IndicatorEntry;
                 } else { // No more indicators on the right
                     var center_children = center_menubar.get_children ();

--- a/src/Widgets/Panel.vala
+++ b/src/Widgets/Panel.vala
@@ -90,7 +90,7 @@ public class Wingpanel.Widgets.Panel : Gtk.Box {
                     var center_children = center_menubar.get_children ();
                     if (center_children.length () > 0) {
                         sibling = center_children.nth_data (0) as IndicatorEntry;
-                    }                    
+                    }
                 }
 
                 break;
@@ -105,7 +105,7 @@ public class Wingpanel.Widgets.Panel : Gtk.Box {
                     var right_children = right_menubar.get_children ();
                     if (right_children.length () > 0) {
                         sibling = right_children.nth_data (0) as IndicatorEntry;
-                    }                    
+                    }
                 }
 
                 break;
@@ -120,13 +120,13 @@ public class Wingpanel.Widgets.Panel : Gtk.Box {
                     var left_children = left_menubar.get_children ();
                     if (left_children.length () > 0) {
                         sibling = left_children.nth_data (0) as IndicatorEntry;
-                    }                    
+                    }
                 }
 
                 break;
         }
 
-        return sibling;     
+        return sibling;
     }
 
     private void add_indicator (Indicator indicator) {


### PR DESCRIPTION
Fixes #7. Makes it possible to use Ctrl+Tab to cycle through indicators. Wingpanel will cycle only when some indicator is currently opened, otherwise, never. To determine the next sibling of the currently opened indicator, I've created `get_next_sibling` helper method in `Wingpanel.Panel` which implements a simple algorithm:

1. Check in what menubar the current indicator is located.
2. If on the left:
- if indicator not found in the menubar, return `null`
- if it's the last indicator in this menubar, return the first one from the center menubar (if exists)
- otherwise, return the next one in this menubar

The same goes for the center and right menubar, except that these will return the next menubar so for center menubar the next will be the right one, and for the right menubar (that is the last), the left will be returned. 

The alghoritm is implemented in a way that if in the future we decide to allow developers to put indicators on the left or center, this will still work, as it's not hardcoded to a particular indicators.

I would like someone to look at the algorithm first and see if it's implemented & works correctly to make sure that this doesn't break anything.

Known issues: Slingshot now cannot switch through categories because it has the same shortcut as cycling.