### PR TITLE
Reconnect to DBus interface when it re-appears

### DIFF
--- a/src/PanelWindow.vala
+++ b/src/PanelWindow.vala
@@ -89,7 +89,7 @@ public class Wingpanel.PanelWindow : Gtk.Window {
     private void on_realize () {
         update_panel_dimensions ();
 
-        Services.BackgroundManager.get_default ().initialize (this.monitor_number, panel_height);
+        Services.BackgroundManager.initialize (this.monitor_number, panel_height);
 
         Timeout.add (300 / panel_height, animation_step);
     }

--- a/src/Services/BackgroundManager.vala
+++ b/src/Services/BackgroundManager.vala
@@ -40,41 +40,46 @@ namespace Wingpanel.Services {
 
         private static BackgroundManager? instance = null;
 
-        private InterfaceBus bus;
+        private InterfaceBus? bus = null;
 
         private BackgroundState current_state = BackgroundState.LIGHT;
         private bool use_transparency = true;
 
+        private bool bus_available {
+            get {
+                return bus != null;
+            }
+        }
+
+        private int monitor;
+        private int panel_height;
+
         public signal void background_state_changed (BackgroundState state, uint animation_duration);
 
-        public BackgroundManager () {
-            if (!connect_dbus ()) {
-                return;
-            }
+        public static void initialize (int monitor, int panel_height) {
+            var manager = BackgroundManager.get_default ();
+            manager.monitor = monitor;
+            manager.panel_height = panel_height;
+        }
 
+        private BackgroundManager () {
             PanelSettings.get_default ().notify["use-transparency"].connect (() => {
                 use_transparency = PanelSettings.get_default ().use_transparency;
                 state_updated ();
             });
 
             use_transparency = PanelSettings.get_default ().use_transparency;
-            state_updated ();
-        }
 
-        public void initialize (int monitor, int panel_height) {
-            try {
-                bus.initialize (monitor, panel_height);
-            } catch (Error e) {
-                warning ("Initializing background manager failed: %s", e.message);
-            }
-
-            bus.state_changed.connect ((state, animation_duration) => {
-                current_state = state;
-                state_updated (animation_duration);
-            });
+            Bus.watch_name (BusType.SESSION, DBUS_NAME, BusNameWatcherFlags.NONE,
+                () => connect_dbus (),
+                () => bus = null);
         }
 
         public void remember_window () {
+            if (!bus_available) {
+                return;
+            }
+
             try {
                 bus.remember_focused_window ();
             } catch (Error e) {
@@ -83,6 +88,10 @@ namespace Wingpanel.Services {
         }
 
         public void restore_window () {
+            if (!bus_available) {
+                return;
+            }
+
             try {
                 bus.restore_focused_window ();
             } catch (Error e) {
@@ -93,12 +102,18 @@ namespace Wingpanel.Services {
         private bool connect_dbus () {
             try {
                 bus = Bus.get_proxy_sync (BusType.SESSION, DBUS_NAME, DBUS_PATH);
+                bus.initialize (monitor, panel_height);
             } catch (Error e) {
                 warning ("Connecting to \"%s\" failed: %s", DBUS_NAME, e.message);
-
                 return false;
             }
 
+            bus.state_changed.connect ((state, animation_duration) => {
+                current_state = state;
+                state_updated (animation_duration);
+            });
+
+            state_updated ();
             return true;
         }
 


### PR DESCRIPTION
This branch makes it so wingpanel will try to reconnect to it's DBus bridge between itself and Gala plugin when it re-appears. This should make wingpanel more relible in some unlikely of cases e.g: Gala crashes. 

This is also much nicer to work with when you're writing code for Gala, testing and restarting the WM. Wingpanel will automatically reconnect to the interface when it appears. On master, this just makes wingpanel disconnect from the interface and not react to any state changes.