### PR TITLE
Calculate actual popover position for mouse event detection

### DIFF
--- a/src/Services/PopoverManager.vala
+++ b/src/Services/PopoverManager.vala
@@ -102,6 +102,27 @@ public class Wingpanel.Services.PopoverManager : Object {
             Gtk.Allocation allocation;
             popover.get_allocation (out allocation);
 
+            Gtk.Allocation indicator_allocation;
+            current_indicator.get_allocation (out indicator_allocation);
+
+            Gtk.Allocation container_allocation;
+            current_indicator.get_parent ().get_allocation (out container_allocation);
+
+            int wingpanel_width;
+            current_indicator.get_root_window ().get_geometry (null, null, out wingpanel_width, null);
+
+            allocation.x += indicator_allocation.x +
+                            container_allocation.x -
+                            ((allocation.width - indicator_allocation.width) / 2);
+
+            if (allocation.x < 0) {
+                allocation.x = 0;
+            }
+
+            if (allocation.x + allocation.width > wingpanel_width) {
+                allocation.x = wingpanel_width - allocation.width;
+            }
+
             if ((e.x < allocation.x || e.x > allocation.x + allocation.width) || (e.y < allocation.y || e.y > allocation.y + allocation.height)) {
                 current_indicator = null;
             }

--- a/src/Services/PopoverManager.vala
+++ b/src/Services/PopoverManager.vala
@@ -109,7 +109,7 @@ public class Wingpanel.Services.PopoverManager : Object {
             current_indicator.get_parent ().get_allocation (out container_allocation);
 
             int wingpanel_width;
-            current_indicator.get_root_window ().get_geometry (null, null, out wingpanel_width, null);
+            owner.get_root_window ().get_geometry (null, null, out wingpanel_width, null);
 
             allocation.x += indicator_allocation.x +
                             container_allocation.x -


### PR DESCRIPTION
Fixes #62 

The allocation of the `Gtk.Box` containing the indicator popover is used to determine if a click was inside the popover or not when deciding whether or not that click event should close the currently open popover.

Because an `Allocation` is relative to its parent this was always `(0, 0)` causing there to be a box the size of the current indicator popover to be in the top left that prevented you from clicking to close indicators. So, this PR does some maths to move the allocation calculation underneath the actual popover relative to the mouse co-ordinates.

I considered removing the mouse bounds check altogether as items inside the popover still receive click events properly. But removing it causes the application menu to be closed when clicking a blank space inside it, so not ideal.