### PR TITLE
Fix 3rd party indicator ordering

### DIFF
--- a/src/Services/IndicatorSorter.vala
+++ b/src/Services/IndicatorSorter.vala
@@ -25,8 +25,8 @@
  * be passed as CompareFuncs.
  */
 public class Wingpanel.Services.IndicatorSorter : Object {
-    private const string UNKNOWN_INDICATOR = "unknown";
-    private const string AYATANA_INDICATOR = "ayatana";
+    private const string UNKNOWN_INDICATOR = "xxx-unknown";
+    private const string AYATANA_INDICATOR = "xxx-ayatana";
 
     /* The order in which the indicators are shown from left to right. */
     private static Gee.HashMap<string, int> INDICATOR_ORDER = new Gee.HashMap<string,int> ();

--- a/src/Services/IndicatorSorter.vala
+++ b/src/Services/IndicatorSorter.vala
@@ -25,18 +25,24 @@
  * be passed as CompareFuncs.
  */
 public class Wingpanel.Services.IndicatorSorter : Object {
+    private const string UNKNOWN_INDICATOR = "unknown";
+    private const string AYATANA_INDICATOR = "ayatana";
+
     /* The order in which the indicators are shown from left to right. */
-    private const string[] INDICATOR_ORDER = {
-        Indicator.KEYBOARD,
-        Indicator.SOUND,
-        Indicator.NETWORK,
-        Indicator.BLUETOOTH,
-        Indicator.PRINTER,
-        Indicator.SYNC,
-        Indicator.POWER,
-        Indicator.MESSAGES,
-        Indicator.SESSION
-    };
+    private static Gee.HashMap<string, int> INDICATOR_ORDER = new Gee.HashMap<string,int> ();
+    static construct {
+        INDICATOR_ORDER[AYATANA_INDICATOR] = 0;
+        INDICATOR_ORDER[UNKNOWN_INDICATOR] = 1;
+        INDICATOR_ORDER[Indicator.KEYBOARD] = 2;
+        INDICATOR_ORDER[Indicator.SOUND] = 3;
+        INDICATOR_ORDER[Indicator.NETWORK] = 4;
+        INDICATOR_ORDER[Indicator.BLUETOOTH] = 5;
+        INDICATOR_ORDER[Indicator.PRINTER] = 6;
+        INDICATOR_ORDER[Indicator.SYNC] = 7;
+        INDICATOR_ORDER[Indicator.POWER] = 8;
+        INDICATOR_ORDER[Indicator.MESSAGES] = 9;
+        INDICATOR_ORDER[Indicator.SESSION] = 10;
+    }
 
     public int compare_func (Wingpanel.Widgets.IndicatorEntry? a, Wingpanel.Widgets.IndicatorEntry? b) {
         if (a == null) {
@@ -65,22 +71,15 @@ public class Wingpanel.Services.IndicatorSorter : Object {
     }
 
     private static int get_order (Wingpanel.Widgets.IndicatorEntry node) {
-        int best_match = 0;
-
         /* ayatana application indicators on the left of the native indicators */
         if (node.base_indicator.code_name.has_prefix ("ayatana-")) {
-            return best_match;
+            return INDICATOR_ORDER[AYATANA_INDICATOR];
         }
 
-        for (int i = 0; i < INDICATOR_ORDER.length; i++) {
-            var order_name = INDICATOR_ORDER[i];
-
-            if (order_name == node.base_indicator.code_name) {
-                best_match = i;
-                break;
-            }
+        if (node.base_indicator.code_name in INDICATOR_ORDER) {
+            return INDICATOR_ORDER[node.base_indicator.code_name];
         }
 
-        return best_match;
+        return INDICATOR_ORDER[UNKNOWN_INDICATOR];
     }
 }

--- a/src/Services/IndicatorSorter.vala
+++ b/src/Services/IndicatorSorter.vala
@@ -29,19 +29,19 @@ public class Wingpanel.Services.IndicatorSorter : Object {
     private const string AYATANA_INDICATOR = "xxx-ayatana";
 
     /* The order in which the indicators are shown from left to right. */
-    private static Gee.HashMap<string, int> INDICATOR_ORDER = new Gee.HashMap<string,int> ();
+    private static Gee.HashMap<string, int> indicator_order = new Gee.HashMap<string,int> ();
     static construct {
-        INDICATOR_ORDER[AYATANA_INDICATOR] = 0;
-        INDICATOR_ORDER[UNKNOWN_INDICATOR] = 1;
-        INDICATOR_ORDER[Indicator.KEYBOARD] = 2;
-        INDICATOR_ORDER[Indicator.SOUND] = 3;
-        INDICATOR_ORDER[Indicator.NETWORK] = 4;
-        INDICATOR_ORDER[Indicator.BLUETOOTH] = 5;
-        INDICATOR_ORDER[Indicator.PRINTER] = 6;
-        INDICATOR_ORDER[Indicator.SYNC] = 7;
-        INDICATOR_ORDER[Indicator.POWER] = 8;
-        INDICATOR_ORDER[Indicator.MESSAGES] = 9;
-        INDICATOR_ORDER[Indicator.SESSION] = 10;
+        indicator_order[AYATANA_INDICATOR] = 0;
+        indicator_order[UNKNOWN_INDICATOR] = 1;
+        indicator_order[Indicator.KEYBOARD] = 2;
+        indicator_order[Indicator.SOUND] = 3;
+        indicator_order[Indicator.NETWORK] = 4;
+        indicator_order[Indicator.BLUETOOTH] = 5;
+        indicator_order[Indicator.PRINTER] = 6;
+        indicator_order[Indicator.SYNC] = 7;
+        indicator_order[Indicator.POWER] = 8;
+        indicator_order[Indicator.MESSAGES] = 9;
+        indicator_order[Indicator.SESSION] = 10;
     }
 
     public int compare_func (Wingpanel.Widgets.IndicatorEntry? a, Wingpanel.Widgets.IndicatorEntry? b) {
@@ -73,13 +73,13 @@ public class Wingpanel.Services.IndicatorSorter : Object {
     private static int get_order (Wingpanel.Widgets.IndicatorEntry node) {
         /* ayatana application indicators on the left of the native indicators */
         if (node.base_indicator.code_name.has_prefix ("ayatana-")) {
-            return INDICATOR_ORDER[AYATANA_INDICATOR];
+            return indicator_order[AYATANA_INDICATOR];
         }
 
-        if (node.base_indicator.code_name in INDICATOR_ORDER) {
-            return INDICATOR_ORDER[node.base_indicator.code_name];
+        if (node.base_indicator.code_name in indicator_order) {
+            return indicator_order[node.base_indicator.code_name];
         }
 
-        return INDICATOR_ORDER[UNKNOWN_INDICATOR];
+        return indicator_order[UNKNOWN_INDICATOR];
     }
 }


### PR DESCRIPTION
@stsdc is developing a system monitor wingpanel indicator and it was appearing between the sound and keyboard indicators.

![zrzut_ekranu_z_2018-01-29_17 56 59](https://user-images.githubusercontent.com/3372394/35527964-51665c06-0524-11e8-8533-d04d18672056.png)


Because the keyboard indicator was at position 0 of the array, it was being alphabetically sorted with the ayatana indicators and any other indicators that came along and weren't defined.

I've taken this opportunity to add "codenames" for both of those categories so we can ensure a consistent sort order with the system indicators sorted after everything else.

This maintains ayatana compatibility for now in case we want to release a new version of wingpanel in the mean time. I assume another PR will come along and rip out the ayatana support at some point :smile: 
