### PR TITLE
Autohide: optionally hide when the mouse is not over panel or indicator menus

### DIFF
--- a/schemas/org.pantheon.desktop.wingpanel.gschema.xml
+++ b/schemas/org.pantheon.desktop.wingpanel.gschema.xml
@@ -6,5 +6,10 @@
 			<summary>Sets if the panel uses transparency.</summary>
 			<description>Disable this to provide higher contrasts and make indicators better readable.</description>
 		</key>
+		<key type="b" name="autohide">
+			<default>false</default>
+			<summary>Sets if the panel will autohide.</summary>
+			<description>Enable this to increase available desktop area and reduce clutter.</description>
+		</key>
 	</schema>
 </schemalist>

--- a/src/PanelWindow.vala
+++ b/src/PanelWindow.vala
@@ -21,6 +21,11 @@ public class Wingpanel.PanelWindow : Gtk.Window {
     public Services.PopoverManager popover_manager;
 
     private Widgets.Panel panel;
+
+    private Gtk.EventBox box;
+
+    uint timeout;
+
     private int monitor_number;
     private int monitor_width;
     private int monitor_height;
@@ -30,6 +35,7 @@ public class Wingpanel.PanelWindow : Gtk.Window {
     private bool expanded = false;
     private int panel_displacement;
     private uint shrink_timeout = 0;
+    private bool autohide = Services.PanelSettings.get_default ().autohide;
 
     public PanelWindow (Gtk.Application application) {
         Object (
@@ -56,6 +62,9 @@ public class Wingpanel.PanelWindow : Gtk.Window {
         update_visual ();
 
         popover_manager = new Services.PopoverManager (this);
+ 
+        box = new Gtk.EventBox();
+        box.add_events (Gdk.EventMask.ENTER_NOTIFY_MASK | Gdk.EventMask.LEAVE_NOTIFY_MASK);
 
         panel = new Widgets.Panel (popover_manager);
         panel.realize.connect (on_realize);
@@ -71,17 +80,40 @@ public class Wingpanel.PanelWindow : Gtk.Window {
         application.add_accelerator ("<Control>Tab", "app.cycle", null);
         application.add_accelerator ("<Control><Shift>Tab", "app.cycle-back", null);
 
-        add (panel);
+        box.add(panel);
+        if (autohide == true) {
+            box.enter_notify_event.connect (reactivate);
+            box.leave_notify_event.connect (on_idle);
+        }
+
+        add (box);
     }
 
     private bool animation_step () {
         if (panel_displacement <= panel_height * (-1)) {
+            timeout = 0;
             return false;
         }
 
         panel_displacement--;
 
-        update_panel_dimensions ();
+        if (autohide == false) { 
+            update_panel_dimensions ();
+        }
+        animate_panel ();
+
+        return true;
+    }
+
+    private bool animation_unstep () {
+        if (panel_displacement >= -1 || popover_manager.current_indicator != null) {
+            timeout = 0;
+            return false;
+        }
+
+        panel_displacement++;
+
+        animate_panel ();
 
         return true;
     }
@@ -91,7 +123,27 @@ public class Wingpanel.PanelWindow : Gtk.Window {
 
         Services.BackgroundManager.initialize (this.monitor_number, panel_height);
 
-        Timeout.add (300 / panel_height, animation_step);
+        timeout = Timeout.add (100 / panel_height, animation_step);
+    }
+
+    private bool on_idle () {
+        if (timeout > 0) {
+            Source.remove (timeout);
+        }
+
+        timeout = Timeout.add (100 / panel_height, animation_unstep);
+
+        return true;
+    }
+
+    private bool reactivate () {
+        if (timeout > 0) {
+            Source.remove (timeout);
+        }
+
+        timeout = Timeout.add (100 / panel_height, animation_step);
+
+        return true;
     }
 
     private void update_panel_dimensions () {
@@ -112,6 +164,24 @@ public class Wingpanel.PanelWindow : Gtk.Window {
         this.move (monitor_x, monitor_y - (panel_height + panel_displacement));
 
         update_struts ();
+    }
+
+    private void animate_panel () {
+        panel_height = panel.get_allocated_height ();
+
+        monitor_number = screen.get_primary_monitor ();
+        Gdk.Rectangle monitor_dimensions;
+        this.screen.get_monitor_geometry (monitor_number, out monitor_dimensions);
+
+        monitor_width = monitor_dimensions.width;
+        monitor_height = monitor_dimensions.height;
+
+        this.set_size_request (monitor_width, (popover_manager.current_indicator != null ? monitor_height : -1));
+
+        monitor_x = monitor_dimensions.x;
+        monitor_y = monitor_dimensions.y;
+
+        this.move (monitor_x, monitor_y - (panel_height + panel_displacement));
     }
 
     private void update_visual () {

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -23,6 +23,8 @@ namespace Wingpanel.Services {
 
         public bool use_transparency { get; set; }
 
+        public bool autohide { get; set; }
+
         public PanelSettings () {
             base ("org.pantheon.desktop.wingpanel");
         }


### PR DESCRIPTION
I think it is worth [reconsidering](https://bugs.launchpad.net/wingpanel/+bug/1079575) autohide for [wingpanel](https://www.bountysource.com/issues/955498-add-optional-hide-mode) as an optional feature.

In fact many applications do not "fullscreen" when told to "maximize" and the presence of the panel enforces a 24px distinction between the two. There are also applications that attempt to draw actionable areas under the panel. Users could enable autohide to have their full resolution available and work around apps that do not play well with panels.

This patch adds an autohide mode and gsetting (org.pantheon.desktop.wingpanel autohide) with the behavior OFF as default.