### PR TITLE
Fix gala hanging when moving a window while changing a wallpaper

### DIFF
--- a/wingpanel-interface/Utils.vala
+++ b/wingpanel-interface/Utils.vala
@@ -31,7 +31,10 @@ namespace WingpanelInterface.Utils {
 
         public override void post_paint () {
             base.post_paint ();
-            done_painting ();
+            Idle.add (() => {
+                done_painting ();
+                return false;
+            });
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/elementary/gala/issues/221

For some reason the X11 backend for Clutter didn't like that we start processing something and interrupt Clutter events. This fixes that by simply fireing the signal at a later time so Clutter takes it's time to process everything and then start updatng the background color info with `Idle.add`.