### PR TITLE
Fix dragging a minimized window

### DIFF
--- a/wingpanel-interface/FocusManager.vala
+++ b/wingpanel-interface/FocusManager.vala
@@ -84,7 +84,7 @@ public class WingpanelInterface.FocusManager : Object {
 
     private static bool get_can_grab_window (Meta.Window window, int x, int y) {
         var frame = window.get_frame_rect ();
-        return window.maximized_vertically && x >= frame.x && x <= frame.x + frame.width;
+        return !window.minimized && window.maximized_vertically && x >= frame.x && x <= frame.x + frame.width;
     }
 
     private void update_current_workspace () {


### PR DESCRIPTION
Bitesize change that prevents dragging minimized and fullscreened windows from the panel, this is possible right now in master.