### PR TITLE
Fix dragging from panel on HiDPI displays

### DIFF
--- a/src/Widgets/Panel.vala
+++ b/src/Widgets/Panel.vala
@@ -95,8 +95,12 @@ public class Wingpanel.Widgets.Panel : Gtk.EventBox {
 
         popover_manager.close ();
 
+        var scale_factor = this.get_scale_factor ();
+        var x = (int)event.x_root * scale_factor;
+        var y = (int)event.y_root * scale_factor;
+
         var background_manager = Services.BackgroundManager.get_default ();
-        return background_manager.begin_grab_focused_window ((int)event.x_root, (int)event.y_root, (int)event.button, time, state);
+        return background_manager.begin_grab_focused_window (x, y, (int)event.button, time, state);
     }
 
     public void cycle (bool forward) {


### PR DESCRIPTION
The coordinates returned from the event need to be multiplied by
the scale factor.

Fixes: https://github.com/elementary/wingpanel/issues/134