### PR TITLE
switch revealer transition fixing re-appear

### DIFF
--- a/src/Widgets/IndicatorEntry.vala
+++ b/src/Widgets/IndicatorEntry.vala
@@ -68,6 +68,12 @@ public class Wingpanel.Widgets.IndicatorEntry : Gtk.MenuItem {
         });
 
         base_indicator.notify["visible"].connect (() => {
+            // switch revealer transition
+            if (revealer.transition_type == Gtk.RevealerTransitionType.SLIDE_LEFT) {
+                revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT;
+            } else if (revealer.transition_type == Gtk.RevealerTransitionType.SLIDE_RIGHT) {
+                revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT;
+            }
             if (menu_bar != null) {
                 /* order will be changed so close all open popovers */
                 popover_manager.close ();


### PR DESCRIPTION
Fixes: #64 

After the bluetooth indicator disappears it doesn't properly re-appear. 
This can be reproduced by running:
```
systemctl restart bluetooth
```
It seems to have something to do with the `RevealerTransitionType.SLIDE_LEFT` transition of the `Gtk.Reveal` that's used for every indicator.

If I add an exception to the following list changing the Reveal transition to anything except SLIDE_LEFT or SLIDE_RIGHT there is no issue.
https://github.com/elementary/wingpanel/blob/master/src/Widgets/Panel.vala#L232-L251

If I switch the transition_type from right to left when the visibility of the indicator is toggled it also re-appears normally. Which is what I'm doing with this PR.