### PR TITLE
Fix revealer using unmap event

### DIFF
--- a/src/Widgets/IndicatorEntry.vala
+++ b/src/Widgets/IndicatorEntry.vala
@@ -38,8 +38,6 @@ public class Wingpanel.Widgets.IndicatorEntry : Gtk.MenuItem {
 
     Services.PopoverManager popover_manager;
 
-    private uint reorder_timeout_id;
-
     public IndicatorEntry (Indicator base_indicator, Services.PopoverManager popover_manager) {
         this.popover_manager = popover_manager;
         this.base_indicator = base_indicator;
@@ -78,10 +76,6 @@ public class Wingpanel.Widgets.IndicatorEntry : Gtk.MenuItem {
                     popover_manager.register_indicator (this);
                     menu_bar.apply_new_order ();
                     set_reveal (base_indicator.visible);
-                    // cancel unmapped reorder
-                    if (reorder_timeout_id > 0) {
-                        Source.remove (reorder_timeout_id);
-                    }
                 } else {
                     set_reveal (base_indicator.visible);
                     popover_manager.unregister_indicator (this);
@@ -128,12 +122,7 @@ public class Wingpanel.Widgets.IndicatorEntry : Gtk.MenuItem {
 
     private void indicator_unmapped () {
         base_indicator.get_display_widget ().unmap.disconnect (indicator_unmapped);
-
-        // using timeout to make it cancelable
-        reorder_timeout_id = Timeout.add (0, () => {
-            menu_bar.apply_new_order ();
-            return false;
-        });
+        menu_bar.apply_new_order ();
     }
 
     public void set_transition_type (Gtk.RevealerTransitionType transition_type) {

--- a/src/Widgets/IndicatorMenuBar.vala
+++ b/src/Widgets/IndicatorMenuBar.vala
@@ -52,10 +52,14 @@ public class Wingpanel.Widgets.IndicatorMenuBar : MenuBar {
     }
 
     public void apply_new_order () {
-        GLib.Source.remove (apply_new_order_idle_id);
+        if (apply_new_order_idle_id > 0) {
+            GLib.Source.remove (apply_new_order_idle_id);
+            apply_new_order_idle_id = 0;
+        }
         apply_new_order_idle_id = GLib.Idle.add_full (GLib.Priority.LOW, () => {
             clear ();
             append_all_items ();
+            apply_new_order_idle_id = 0;
             return false;
         });
     }

--- a/src/Widgets/IndicatorMenuBar.vala
+++ b/src/Widgets/IndicatorMenuBar.vala
@@ -20,7 +20,7 @@
 public class Wingpanel.Widgets.IndicatorMenuBar : MenuBar {
     private Gee.List<IndicatorEntry> sorted_items;
     private Services.IndicatorSorter sorter = new Services.IndicatorSorter ();
-    private uint apply_new_order_idle_id;
+    private uint apply_new_order_idle_id = 0;
 
     public IndicatorMenuBar () {
         sorted_items = new Gee.ArrayList<IndicatorEntry> ();

--- a/src/Widgets/IndicatorMenuBar.vala
+++ b/src/Widgets/IndicatorMenuBar.vala
@@ -20,6 +20,7 @@
 public class Wingpanel.Widgets.IndicatorMenuBar : MenuBar {
     private Gee.List<IndicatorEntry> sorted_items;
     private Services.IndicatorSorter sorter = new Services.IndicatorSorter ();
+    private uint apply_new_order_idle_id;
 
     public IndicatorMenuBar () {
         sorted_items = new Gee.ArrayList<IndicatorEntry> ();
@@ -51,8 +52,12 @@ public class Wingpanel.Widgets.IndicatorMenuBar : MenuBar {
     }
 
     public void apply_new_order () {
-        clear ();
-        append_all_items ();
+        GLib.Source.remove (apply_new_order_idle_id);
+        apply_new_order_idle_id = GLib.Idle.add_full (GLib.Priority.LOW, () => {
+            clear ();
+            append_all_items ();
+            return false;
+        });
     }
 
     private void clear () {


### PR DESCRIPTION
Fixes: elementary/wingpanel-indicator-bluetooth#64
Supersedes: #174

After the bluetooth indicator disappears it sometimes doesn't properly re-appear. 
This can be reproduced by running:
```
systemctl restart bluetooth
```

I can also reproduce the issue by rapidly switching nightlight on off. You see it sometimes not showing up or even showing only half of the icon:
![screen record from 2019-01-11 21 20 15](https://user-images.githubusercontent.com/523210/51057785-ed55df00-15e6-11e9-9266-0c19de6ede28.gif)
![screen record from 2019-01-11 21 19 21](https://user-images.githubusercontent.com/523210/51057786-edee7580-15e6-11e9-9e62-11f226d6757e.gif)
(Using <kbd>Enter</kbd> to switch the button makes this easier)

I noticed I could fix this by commenting the delayed re-ordering:
https://github.com/elementary/wingpanel/blob/master/src/Widgets/IndicatorEntry.vala#L82-L85
But this means the indicator isn't removed and you'll see extra margins. 

Removing the previous timeout and increasing the interval helps a great deal. But that means another arbitrary value, which could still give issues on slower systems and adds a delayed sudden jump in the indicators. 

I was hoping to find a solution like: https://github.com/elementary/wingpanel/pull/155

This PR's uses the `unmap` signal to know a indicator is hidden, it then start a 0ms timeout to request the menubar reordering. The timeout makes it cancelable when the indicator is quickly made visible again.

Still feels like quite a workaround, I'm open for better solutions. 
Disconnecting from the `unmap` signal when the indicator is made visible again gave issues for some reason. 
It could be that a better solution is doing a less crude reordering in the menubar?