### PR TITLE
Fix wingpanel potentially overlapping windows

### DIFF
--- a/src/Widgets/Panel.vala
+++ b/src/Widgets/Panel.vala
@@ -30,7 +30,7 @@ public class Wingpanel.Widgets.Panel : Gtk.EventBox {
     public Panel (Services.PopoverManager popover_manager) {
         Object (popover_manager : popover_manager);
 
-        this.set_size_request (-1, 24);
+        this.set_size_request (-1, 30);
 
         this.hexpand = true;
         this.vexpand = true;


### PR DESCRIPTION
Fixes: #130

I noticed that sometimes my wingpanel would overlap left/right tiled windows. Looking into it it seemed like the allocated height of the panel changed from 24 (the requested height) to 30. For some people, in some cases this switch would happen after the [slide in animation](https://github.com/elementary/wingpanel/blob/master/src/PanelWindow.vala#L76-L86) where the [truts](https://github.com/elementary/wingpanel/blob/master/src/PanelWindow.vala#L126-L153)? are updated. 

I filtered out all indicators and it seemed like these indicators caused the panel's height to go from 24 to 30:
- [session](https://github.com/elementary/wingpanel-indicator-session)
- [network](https://github.com/elementary/wingpanel-indicator-network)
- [sound](https://github.com/elementary/wingpanel-indicator-sound)
- [power](https://github.com/elementary/wingpanel-indicator-power/)

You can also see that those 4 have a margin above and below:
![screenshot from 2019-02-25 22-49-18](https://user-images.githubusercontent.com/523210/53371128-b9910780-394f-11e9-9844-667bf17cb8e7.png)

I'm assuming we actually like the 30, so this PR makes sure we start of at 30. 

For comparison:
24 height:
![screenshot from 2019-02-25 22-03-15](https://user-images.githubusercontent.com/523210/53368575-76339a80-3949-11e9-87bf-d8c6121016a9.png)
30 height:
![screenshot from 2019-02-25 22-05-10](https://user-images.githubusercontent.com/523210/53368584-7af84e80-3949-11e9-99ca-8fab83f880a1.png)
