### PR TITLE
Fix moving window to another workspace not updating wingpanel state

### DIFF
--- a/wingpanel-interface/BackgroundManager.vala
+++ b/wingpanel-interface/BackgroundManager.vala
@@ -116,6 +116,10 @@ public class WingpanelInterface.BackgroundManager : Object {
         window.notify["minimized"].connect (() => {
             check_for_state_change (AnimationSettings.get_default ().minimize_duration);
         });
+
+        window.workspace_changed.connect (() => {
+            check_for_state_change (AnimationSettings.get_default ().minimize_duration);
+        });
     }
 
     private void on_window_added (Meta.Window window) {


### PR DESCRIPTION
Fixes https://github.com/elementary/gala/issues/497.

Changing the workspace of a window didn't cause an update to the wingpanel background state. Now it does.