### PR TITLE
Keep better record of focused apps

### DIFF
--- a/wingpanel-interface/FocusManager.vala
+++ b/wingpanel-interface/FocusManager.vala
@@ -34,8 +34,7 @@ public class WingpanelInterface.FocusManager : Object {
     public void remember_focused_window () {
         var windows = current_workspace.list_windows ();
         foreach (Meta.Window window in windows) {
-            window.focused.connect (window_focused);
-            window.unmanaged.connect (window_unmanaged);
+            window_created (window);
             if (window.has_focus ()) {
                 last_focused_window = window;
             }


### PR DESCRIPTION
Fixes: #205 and https://github.com/elementary/applications-menu/issues/19

Following @davidmhewitt advice to listen for window focus changes fixing the following hypothesis:

> Smaller, faster apps manage to open their window and grab focus before this code restores the (wrong) previously focused window. Whereas slower apps take focus after the previously focused window has been given focus back.