### PR TITLE
Fix panel transparency calculations

### DIFF
--- a/wingpanel-interface/Utils.vala
+++ b/wingpanel-interface/Utils.vala
@@ -61,7 +61,11 @@ namespace WingpanelInterface.Utils {
         var bg_actor_width = (int)background.width;
         var bg_actor_height = (int)background.height;
 
-        // Avoid looking at the edges of the texture as it often has a black border
+        // A commit in mutter added some padding to offscreen textures, so we
+        // need to avoid looking at the edges of the texture as it often has a
+        // black border. The commit specifies that up to 1.75px around each side
+        // could now be padding, so cut off 2px from left and top if necessary
+        // (https://gitlab.gnome.org/GNOME/mutter/commit/8655bc5d8de6a969e0ca83eff8e450f62d28fbee)
         int x_start = reference_x;
         if (x_start < 2) {
             x_start = 2;
@@ -72,8 +76,10 @@ namespace WingpanelInterface.Utils {
             y_start = 2;
         }
 
-        // If the caller has specified an area of interest smaller than 2px less than the width/height,
-        // use that, otherwise chop 2px off the edges again
+        // For the same reason as above, we need to not use the bottom and right
+        // 2px of the texture. However, if the caller has specified an area of
+        // interest that already misses these parts, use that instead, otherwise
+        // chop 2px
         int width = int.min (bg_actor_width - 2 - reference_x, reference_width);
         int height = int.min (bg_actor_height - 2 - reference_y, reference_height);
 


### PR DESCRIPTION
Fixes #207 

The new mutter version seems to give us a texture that's 3px in both dimensions bigger than the background actor that the texture is rendered from. This tends to leave a darker border around the texture, which doesn't help the calculations.

Adjust the logic to ignore 2px from every side of the texture we pull from clutter and also fix the following logic errors while we're here:
 - Luminance calculations were being done with reversed RGB values
 - Copy and paste error in argument range check
 - Calculations didn't account for an offset start position other than 0 and would only calculate on an area of (requested size - offset) rather than the requested area

This will need testing with a variety of backgrounds again to make sure it's doing sensible things, but it seems much closer to the old behaviour again.

Remember to install and reboot/restart gala to test as this is a gala plugin.