### PR TITLE
Disable GtkWidget-window-dragging on panel

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -7,3 +7,9 @@ install_data(
     'wingpanel.svg',
     install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', 'scalable', 'apps')
 )
+
+# Use GResource
+css_gresource = gnome.compile_resources(
+    'gresource_css',
+    meson.project_name() + '.gresource.xml'
+)

--- a/data/styles/application.css
+++ b/data/styles/application.css
@@ -1,0 +1,3 @@
+.panel {
+    -GtkWidget-window-dragging: false;
+}

--- a/data/wingpanel.gresource.xml
+++ b/data/wingpanel.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/io/elementary/wingpanel">
+    <file alias="application.css" compressed="true">styles/application.css</file>
+  </gresource>
+</gresources>

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,7 @@ add_project_arguments([
 indicators_dir = join_paths(get_option('prefix'), get_option('libdir'), 'wingpanel')
 
 i18n = import('i18n')
+gnome = import('gnome')
 pkg = import('pkgconfig')
 
 glib_dep = dependency('glib-2.0', version: '>=2.32')

--- a/src/PanelWindow.vala
+++ b/src/PanelWindow.vala
@@ -48,6 +48,20 @@ public class Wingpanel.PanelWindow : Gtk.Window {
         style_context.add_class (Widgets.StyleClass.PANEL);
         style_context.add_class (Gtk.STYLE_CLASS_MENUBAR);
 
+        var style_provider = new Gtk.CssProvider ();
+        style_context.add_provider (style_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        string css = """
+            .panel {
+                -GtkWidget-window-dragging: false;
+            }
+        """;
+
+        try {
+            style_provider.load_from_data (css, css.length);
+        } catch (Error e) {
+            warning ("Parsing own style configuration failed: %s", e.message);
+        }
+
         this.screen.size_changed.connect (update_panel_dimensions);
         this.screen.monitors_changed.connect (update_panel_dimensions);
         this.screen_changed.connect (update_visual);

--- a/src/PanelWindow.vala
+++ b/src/PanelWindow.vala
@@ -48,19 +48,9 @@ public class Wingpanel.PanelWindow : Gtk.Window {
         style_context.add_class (Widgets.StyleClass.PANEL);
         style_context.add_class (Gtk.STYLE_CLASS_MENUBAR);
 
-        var style_provider = new Gtk.CssProvider ();
-        style_context.add_provider (style_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-        string css = """
-            .panel {
-                -GtkWidget-window-dragging: false;
-            }
-        """;
-
-        try {
-            style_provider.load_from_data (css, css.length);
-        } catch (Error e) {
-            warning ("Parsing own style configuration failed: %s", e.message);
-        }
+        var provider = new Gtk.CssProvider ();
+        provider.load_from_resource ("io/elementary/wingpanel/application.css");
+        style_context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         this.screen.size_changed.connect (update_panel_dimensions);
         this.screen.monitors_changed.connect (update_panel_dimensions);

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,6 +19,7 @@ wingpanel_deps = [
 ]
 
 executable(meson.project_name(),
+    css_gresource,
     wingpanel_files,
     dependencies: wingpanel_deps,
     install: true


### PR DESCRIPTION
Fixes #169 

We were inheriting `-GtkWidget-window-dragging: true;` from `Gtk.STYLE_CLASS_MENUBAR` which was causing the issue of being able to drag the panel around with 2+ fingers on a touchscreen.

I don't know if we want to do this in a neater way (i.e. in a GResource or by doing something in the stylesheet), but this seems to be the cause of the issue and fixes it for me.