### PR TITLE
PopoverManager: use allocated_width

### DIFF
--- a/src/Services/PopoverManager.vala
+++ b/src/Services/PopoverManager.vala
@@ -119,8 +119,7 @@ public class Wingpanel.Services.PopoverManager : Object {
             Gtk.Allocation container_allocation;
             current_indicator.get_parent ().get_allocation (out container_allocation);
 
-            int wingpanel_width;
-            owner.get_root_window ().get_geometry (null, null, out wingpanel_width, null);
+            var wingpanel_width = owner.get_allocated_width ();
 
             allocation.x += indicator_allocation.x +
                             container_allocation.x -


### PR DESCRIPTION
`Gtk.Widget.get_root_window` is deprecated

Since `owner` is a Gtk.Window (and thus a Gtk.Widget subclass), it seems like we can just use `get_allocated_width` here right?