### PR TITLE
Register with the session manager

### DIFF
--- a/src/SessionManager.vala
+++ b/src/SessionManager.vala
@@ -1,0 +1,74 @@
+/*-
+ * Copyright (c) 2015-2016 elementary LLC.
+ * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Adam Bieńkowski <donadigos159@gmail.com>
+ */
+
+/*
+ * Code based on budgie-desktop:
+ * https://github.com/solus-project/budgie-desktop
+ */
+
+namespace Wingpanel.SessionManager {
+    [DBus (name = "org.gnome.SessionManager")]
+    public interface SessionManager : Object {
+        public abstract async ObjectPath register_client (string app_id, string client_start_id) throws GLib.Error;
+    }
+
+    [DBus (name = "org.gnome.SessionManager.ClientPrivate")]
+    public interface SessionClient : Object {
+        public abstract void end_session_response (bool is_ok, string reason) throws GLib.Error;
+
+        public signal void stop ();
+        public signal void query_end_session (uint flags);
+        public signal void end_session (uint flags);
+        public signal void cancel_end_session ();
+    }
+
+    public const string GNOME_SESSION_MANAGER_IFACE = "org.gnome.SessionManager";
+    public const string GNOME_SESSION_MANAGER_PATH = "/org/gnome/SessionManager";
+
+    public async SessionClient? register_with_session (string app_id) {
+        SessionClient? sclient = null;
+        ObjectPath? path = null;
+
+        string? start_id = Environment.get_variable ("DESKTOP_AUTOSTART_ID");
+        if (start_id != null) {
+            Environment.unset_variable ("DESKTOP_AUTOSTART_ID");
+        } else {
+            start_id = "";
+        }
+
+        try {
+            SessionManager? session = yield Bus.get_proxy (BusType.SESSION, GNOME_SESSION_MANAGER_IFACE, GNOME_SESSION_MANAGER_PATH);
+            path = yield session.register_client (app_id, start_id);
+        } catch (Error e) {
+            warning ("Error registering client: %s", e.message);
+            return null;
+        }
+
+        try {
+            sclient = yield Bus.get_proxy (BusType.SESSION, GNOME_SESSION_MANAGER_IFACE, path);
+        } catch (Error e) {
+            warning ("Unable to get Private Client proxy: %s", e.message);
+            return null;
+        }
+
+        return sclient;
+    }
+}
+

--- a/src/SessionManager.vala
+++ b/src/SessionManager.vala
@@ -71,4 +71,3 @@ namespace Wingpanel.SessionManager {
         return sclient;
     }
 }
-

--- a/src/Wingpanel.vala
+++ b/src/Wingpanel.vala
@@ -46,6 +46,40 @@ namespace Wingpanel {
             application_id = "org.elementary.wingpanel";
 
             add_main_option_entries (OPTIONS);
+
+            register_with_session.begin ((obj, res) => {
+                bool success = register_with_session.end (res);
+                if (!success) {
+                    warning ("Failed to register with Session manager");
+                }
+            });
+        }
+
+        private async bool register_with_session () {
+            var sclient = yield SessionManager.register_with_session ("io.elementary.wingpanel");
+            if (sclient == null) {
+                return false;
+            }
+
+            sclient.query_end_session.connect (session_respond);
+            sclient.end_session.connect (session_respond);
+            sclient.stop.connect (session_stop);
+
+            return true;
+        }
+
+        private void session_respond (SessionManager.SessionClient sclient, uint flags) {
+            try {
+                sclient.end_session_response (true, "");
+            } catch (Error e) {
+                warning ("Unable to respond to session manager: %s", e.message);
+            }
+        }
+
+        private void session_stop () {
+            if (panel_window != null) {
+                panel_window.destroy ();
+            }
         }
 
         public static WingpanelApp _instance = null;

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,7 @@
 wingpanel_files = files(
-    'Wingpanel.vala',
     'PanelWindow.vala',
+    'SessionManager.vala',
+    'Wingpanel.vala',
     'Services/BackgroundManager.vala',
     'Services/IndicatorSorter.vala',
     'Services/PopoverManager.vala',


### PR DESCRIPTION
To be tested in conjunction with #274 

Session manager code copied verbatim from polkit agent and just re-namespaced so copyright headers left intact.

May need to do the equivalent for plank too if this fixes the delayed startup thing @danrabbit was seeing while testing #274 . 