### PR TITLE
Remove deprecated properties from SampleIndicator

### DIFF
--- a/sample/SampleIndicator.vala
+++ b/sample/SampleIndicator.vala
@@ -31,9 +31,7 @@ public class Sample.Indicator : Wingpanel.Indicator {
     public Indicator () {
         /* Some information about the indicator */
         Object (
-            code_name : "sample-indicator", /* Unique name */
-            display_name : _("Sample Indicator"), /* Localised name */
-            description: _("Does nothing, but it is cool!") /* Short description */
+            code_name : "sample-indicator" /* Unique name */
         );
     }
 


### PR DESCRIPTION
`display_name` & `description` were deprecated in https://github.com/elementary/wingpanel/commit/86098c2059e7fa6af82f888f755aeec31d00fd31