### PR TITLE
Separator: Mark as deprecated

### DIFF
--- a/lib/Widgets/Separator.vala
+++ b/lib/Widgets/Separator.vala
@@ -17,6 +17,7 @@
  * Boston, MA 02110-1301 USA.
  */
 
+[Version (deprecated = true, deprecated_since = "3.0.0", replacement = "Gtk.Separator")]
 public class Wingpanel.Widgets.Separator : Gtk.Separator {
     public Separator () {
         Object (


### PR DESCRIPTION
If we really need this convenience, it should probably be a stylesheet feature instead