### PR TITLE
Application.css: Hard code -gtk-icon-palette

### DIFF
--- a/data/styles/application.css
+++ b/data/styles/application.css
@@ -14,6 +14,10 @@
     -gtk-icon-shadow:
         0 0 2px alpha (#000, 0.3),
         0 1px 2px alpha (#000, 0.6);
+    -gtk-icon-palette:
+        error @STRAWBERRY_300,
+        success @LIME_300,
+        warning mix(@BANANA_300, @BANANA_500, 0.5);
 }
 
 .panel.color-light .composited-indicator > revealer label,
@@ -26,4 +30,8 @@
     -gtk-icon-shadow:
         0 0 2px alpha (#fff, 0.3),
         0 1px 0 alpha (#fff, 0.25);
+    -gtk-icon-palette:
+        error @STRAWBERRY_700,
+        success mix(@LIME_700, @LIME_900, 0.5),
+        warning mix(@BANANA_700, @BANANA_900, 0.5);
 }


### PR DESCRIPTION
Fixes #317 

This makes colors in icons change based on the panel color itself, not on whether popovers are light or dark