### PR TITLE
Add codenames for missing indicators

### DIFF
--- a/lib/Indicator.vala
+++ b/lib/Indicator.vala
@@ -29,6 +29,9 @@ public abstract class Wingpanel.Indicator : GLib.Object {
     public const string PRINTER = "printer";
     public const string BLUETOOTH = "bluetooth";
     public const string KEYBOARD = "keyboard";
+    public const string NIGHT_LIGHT = "nightlight";
+    public const string PRIVACY = "privacy";
+    public const string ACCESSIBILITY = "a11y";
 
     /**
      * The unique name representing the indicator.

--- a/src/Services/IndicatorSorter.vala
+++ b/src/Services/IndicatorSorter.vala
@@ -33,15 +33,18 @@ public class Wingpanel.Services.IndicatorSorter : Object {
     static construct {
         indicator_order[AYATANA_INDICATOR] = 0;
         indicator_order[UNKNOWN_INDICATOR] = 1;
-        indicator_order[Indicator.KEYBOARD] = 2;
-        indicator_order[Indicator.SOUND] = 3;
-        indicator_order[Indicator.NETWORK] = 4;
-        indicator_order[Indicator.BLUETOOTH] = 5;
-        indicator_order[Indicator.PRINTER] = 6;
-        indicator_order[Indicator.SYNC] = 7;
-        indicator_order[Indicator.POWER] = 8;
-        indicator_order[Indicator.MESSAGES] = 9;
-        indicator_order[Indicator.SESSION] = 10;
+        indicator_order[Indicator.ACCESSIBILITY] = 2;
+        indicator_order[Indicator.NIGHT_LIGHT] = 3;
+        indicator_order[Indicator.PRIVACY] = 4;
+        indicator_order[Indicator.KEYBOARD] = 5;
+        indicator_order[Indicator.SOUND] = 6;
+        indicator_order[Indicator.NETWORK] = 7;
+        indicator_order[Indicator.BLUETOOTH] = 8;
+        indicator_order[Indicator.PRINTER] = 9;
+        indicator_order[Indicator.SYNC] = 10;
+        indicator_order[Indicator.POWER] = 11;
+        indicator_order[Indicator.MESSAGES] = 12;
+        indicator_order[Indicator.SESSION] = 13;
     }
 
     public int compare_func (Wingpanel.Widgets.IndicatorEntry? a, Wingpanel.Widgets.IndicatorEntry? b) {


### PR DESCRIPTION
This adds the following three constants:

```vala
public const string NIGHT_LIGHT = "nightlight";
public const string PRIVACY = "privacy";
public const string ACCESSIBILITY = "a11y";
```

Let me know if the indicator sorting as in #366 should be in this PR. I've left it out of this PR so the design team can add it in instead.