### PR TITLE
deb-packaging: Remove .so from -dev package

### DIFF
--- a/debian/libwingpanel-3.0-dev.install
+++ b/debian/libwingpanel-3.0-dev.install
@@ -1,4 +1,3 @@
 usr/include
-usr/lib/*/libwingpanel-3.0.so
 usr/lib/*/pkgconfig
 usr/share/vala


### PR DESCRIPTION
I'm pretty sure this shouldn't be here as it conflicts with the `libwingpanel-3.0` package.