### PR TITLE
deb-packaging: Fix .so version installation

### DIFF
--- a/debian/libwingpanel-3.0-0.install
+++ b/debian/libwingpanel-3.0-0.install
@@ -1,1 +1,1 @@
-usr/lib/*/libwingpanel-3.0.so*
+usr/lib/*/libwingpanel-3.0.so.*


### PR DESCRIPTION
This package shouldn't install the `libwingpanel-3.0.so` symlink as this is in the `-dev` package.