### PR TITLE
AppData: Remove desktop app type

### DIFF
--- a/data/wingpanel.appdata.xml.in
+++ b/data/wingpanel.appdata.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2015–2021 elementary, Inc. <contact@elementary.io> -->
-<component type="desktop-application">
+<component>
   <id>io.elementary.wingpanel</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_group>elementary</project_group>


### PR DESCRIPTION
WingPanel is not what you'd consider a desktop app, and components like Gala lack this type definition. May resolve https://github.com/elementary/appcenter/issues/1758