### PR TITLE
Application: Only load dark style preference in session

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -82,6 +82,15 @@ public class Wingpanel.Application : Gtk.Application {
             IndicatorManager.get_default ().initialize (IndicatorManager.ServerType.GREETER);
         } else {
             IndicatorManager.get_default ().initialize (IndicatorManager.ServerType.SESSION);
+
+            var granite_settings = Granite.Settings.get_default ();
+            var gtk_settings = Gtk.Settings.get_default ();
+
+            gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
+
+            granite_settings.notify["prefers-color-scheme"].connect (() => {
+                gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
+            });
         }
 
         if (options.contains (OPEN_INDICATOR_ACTION_NAME)) {

--- a/src/Widgets/Panel.vala
+++ b/src/Widgets/Panel.vala
@@ -83,15 +83,6 @@ public class Wingpanel.Widgets.Panel : Gtk.EventBox {
         style_context.add_provider (resource_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         Services.BackgroundManager.get_default ().background_state_changed.connect (update_background);
-
-        var granite_settings = Granite.Settings.get_default ();
-        var gtk_settings = Gtk.Settings.get_default ();
-
-        gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
-
-        granite_settings.notify["prefers-color-scheme"].connect (() => {
-            gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
-        });
     }
 
     public override bool button_press_event (Gdk.EventButton event) {


### PR DESCRIPTION
This is kind of a hotfix for startup delays on the greeter. I'm not sure what the proper long-term solution should be, but this resolves it in a simple way