### PR TITLE
deb-packaging: Explicitly add libmutter deps

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: elementary, Inc. <builds@elementary.io>
 Build-Depends: debhelper (>= 10.5.1),
                gettext,
                libgala-dev,
+               libmutter-10-dev | libmutter-9-dev | libmutter-8-dev | libmutter-7-dev | libmutter-6-dev,
                libgee-0.8-dev,
                libgirepository1.0-dev,
                libglib2.0-dev (>= 2.32),


### PR DESCRIPTION
Makes it more clear that this is a build dependency and allows us to bump this to cause a rebuild if the versions change.