### PR TITLE
Fallback to maximized style if Gala bus is unavailable

### DIFF
--- a/src/Services/BackgroundManager.vala
+++ b/src/Services/BackgroundManager.vala
@@ -76,7 +76,12 @@ namespace Wingpanel.Services {
 
             Bus.watch_name (BusType.SESSION, DBUS_NAME, BusNameWatcherFlags.NONE,
                 () => connect_dbus (),
-                () => bus = null);
+                () => {
+                    bus = null;
+                    // If the Gala bus is unavailable or vanishes, fall back to maximized style,
+                    // as this is most visible on all backgrounds
+                    background_state_changed (BackgroundState.MAXIMIZED, 0);
+                });
         }
 
         public void remember_window () {


### PR DESCRIPTION
Currently, if you run wingpanel on a compositor that doesn't have the Gala DBus interface for checking the wallpaper colour, it defaults to a fully transparent light style which may not be ideal depending on the wallpaper.

It would be better to just have to solid black maximized panel in cases where the Gala DBus interface isn't available. This would either be because the compositor isn't Gala and doesn't implement the interface, or because Gala crashed (and you've got bigger issues than the colour of your panel)