### PR TITLE
Styles: fix CSS syntax, remove extra class

### DIFF
--- a/data/styles/application.css
+++ b/data/styles/application.css
@@ -8,12 +8,12 @@
     color: #fff;
     font-weight: bold;
     text-shadow:
-        0 0 2px alpha (#000, 0.3),
-        0 1px 2px alpha (#000, 0.6);
+        0 0 2px alpha(#000, 0.3),
+        0 1px 2px alpha(#000, 0.6);
     transition: all 200ms ease-in-out;
     -gtk-icon-shadow:
-        0 0 2px alpha (#000, 0.3),
-        0 1px 2px alpha (#000, 0.6);
+        0 0 2px alpha(#000, 0.3),
+        0 1px 2px alpha(#000, 0.6);
     -gtk-icon-palette:
         error @STRAWBERRY_300,
         success @LIME_300,
@@ -23,13 +23,13 @@
 .panel.color-light .composited-indicator > revealer label,
 .panel.color-light .composited-indicator > revealer image,
 .panel.color-light .composited-indicator > revealer spinner {
-    color: alpha (#000, 0.65);
+    color: alpha(#000, 0.65);
     text-shadow:
-        0 0 2px alpha (#fff, 0.3),
-        0 1px 0 alpha (#fff, 0.25);
+        0 0 2px alpha(#fff, 0.3),
+        0 1px 0 alpha(#fff, 0.25);
     -gtk-icon-shadow:
-        0 0 2px alpha (#fff, 0.3),
-        0 1px 0 alpha (#fff, 0.25);
+        0 0 2px alpha(#fff, 0.3),
+        0 1px 0 alpha(#fff, 0.25);
     -gtk-icon-palette:
         error @STRAWBERRY_700,
         success mix(@LIME_700, @LIME_900, 0.5),

--- a/data/styles/application.css
+++ b/data/styles/application.css
@@ -1,5 +1,5 @@
 .composited-indicator {
-    padding: 0 3px;
+    padding: 0 6px;
 }
 
 .composited-indicator > revealer label,

--- a/data/styles/panel.css
+++ b/data/styles/panel.css
@@ -2,7 +2,7 @@
     background-color: transparent;
     transition: all 100ms ease-in-out;
     margin-bottom: 0;
-    -GtkWidget-window-dragging: false;
+    min-height: 16px;
 }
 
 .panel.maximized {

--- a/src/PanelWindow.vala
+++ b/src/PanelWindow.vala
@@ -44,12 +44,11 @@ public class Wingpanel.PanelWindow : Gtk.Window {
 
         monitor_number = screen.get_primary_monitor ();
 
-        var style_context = get_style_context ();
-        style_context.add_class (Widgets.StyleClass.PANEL);
-        style_context.add_class (Gtk.STYLE_CLASS_MENUBAR);
-
         var panel_provider = new Gtk.CssProvider ();
         panel_provider.load_from_resource ("io/elementary/wingpanel/panel.css");
+
+        var style_context = get_style_context ();
+        style_context.add_class (Widgets.StyleClass.PANEL);
         style_context.add_provider (panel_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         var app_provider = new Gtk.CssProvider ();

--- a/src/Widgets/IndicatorEntry.vala
+++ b/src/Widgets/IndicatorEntry.vala
@@ -55,9 +55,6 @@ public class Wingpanel.Widgets.IndicatorEntry : Gtk.MenuItem {
             return;
         }
 
-        display_widget.margin_start = 4;
-        display_widget.margin_end = 4;
-
         revealer = new Gtk.Revealer ();
         revealer.add (display_widget);
 


### PR DESCRIPTION
Some style fixes ahead of Gtk4 to reduce the diff there

* Fix CSS syntax error with `alpha`
* Remove old `window-dragging`
* Set a min-height to avoid divide by zero
* Don't see `menubar` because it doesn't seem like there's a reason to set it here and the class doesn't exist in Gtk4
* Remove hardcoded margin in IndicatorEntry