### PR TITLE
build: Fix building with gala 6.3.2

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -16,8 +16,7 @@ wingpanel_files = files(
 wingpanel_deps = [
     libwingpanel_dep,
     granite_dep,
-    gdk_x11_dep,
-    posix_dep
+    gdk_x11_dep
 ]
 
 executable(meson.project_name(),

--- a/wingpanel-interface/meson.build
+++ b/wingpanel-interface/meson.build
@@ -84,7 +84,7 @@ shared_module(
     'BackgroundManager.vala',
     'FocusManager.vala',
     'Utils.vala',
-    dependencies: [gala_dep, granite_dep, mutter_dep, m_dep],
+    dependencies: [gala_dep, granite_dep, mutter_dep, m_dep, posix_dep],
     vala_args: vala_flags,
     c_args: c_flags,
     install_rpath: mutter_typelib_dir,


### PR DESCRIPTION
See https://github.com/elementary/gala/issues/1471

Since the error comes from gala.vapi, I guess the posix_dep can be placed next to gala_dep?