### PR TITLE
IndicatorMenuBar: Do not try to readd an already added child

### DIFF
--- a/data/wingpanel.appdata.xml.in
+++ b/data/wingpanel.appdata.xml.in
@@ -12,7 +12,19 @@
   </description>
 
   <releases>
-    <release version="3.0.4" date="2023-18-28" urgency="medium">
+    <release version="3.0.5" date="2023-09-13" urgency="medium">
+      <description>
+        <p>Improvements:</p>
+        <ul>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+      <issues>
+        <issue url="https://github.com/elementary/wingpanel/issues/502">The WiFi indicator keeps moving over to the left side next to the calendar and time</issue>
+      </issues>
+    </release>
+
+    <release version="3.0.4" date="2023-08-28" urgency="medium">
       <description>
         <p>Improvements:</p>
         <ul>

--- a/src/Widgets/IndicatorMenuBar.vala
+++ b/src/Widgets/IndicatorMenuBar.vala
@@ -45,7 +45,9 @@ public class Wingpanel.Widgets.IndicatorMenuBar : Gtk.MenuBar {
                 }
             }
 
-            this.insert (item, index);
+            if (item.get_parent () != this) {
+                this.insert (item, index);
+            }
         }
     }
 


### PR DESCRIPTION
Prevents the MenuBar to allocate space for the previous position of this.

Closes: https://github.com/elementary/wingpanel/issues/502