### PR TITLE
FocusManager: Make sure to never reuse a freed Window

### DIFF
--- a/wingpanel-interface/FocusManager.vala
+++ b/wingpanel-interface/FocusManager.vala
@@ -18,9 +18,9 @@
  */
 
 public class WingpanelInterface.FocusManager : Object {
-    private unowned Meta.Workspace? current_workspace = null;
-    private unowned Meta.Window? last_focused_window = null;
-    private unowned Meta.Window? last_focused_dialog_window = null;
+    private Meta.Workspace? current_workspace = null;
+    private Meta.Window? last_focused_window = null;
+    private Meta.Window? last_focused_dialog_window = null;
 
     public FocusManager () {
         unowned Meta.WorkspaceManager manager = Main.display.get_workspace_manager ();
@@ -83,6 +83,10 @@ public class WingpanelInterface.FocusManager : Object {
     void window_unmanaged (Meta.Window window) {
         window.focused.disconnect (window_focused);
         window.unmanaged.disconnect (window_unmanaged);
+
+        if (last_focused_window == window) {
+            last_focused_window = null;
+        }
     }
 
     public bool begin_grab_focused_window (int x, int y, int button, uint time, uint state) {


### PR DESCRIPTION
Fixes crash that can occur when opening slingshot:
```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007582916f1549 in meta_window_focus (window=window@entry=0x603df009b880, timestamp=0) at ../src/core/window.c:4670
[Current thread is 1 (Thread 0x75828faeeb00 (LWP 1758))]
(gdb) bt
#0  0x00007582916f1549 in meta_window_focus (window=window@entry=0x603df009b880, timestamp=0) at ../src/core/window.c:4670
#1  0x000075828848a1d1 in wingpanel_interface_focus_manager_restore_focused_window (self=0x603defc3a9d0 [WingpanelInterfaceFocusManager])
    at wingpanel-interface/libwingpanel-interface.so.p/FocusManager.c:246
#2  0x000075828848a3f6 in wingpanel_interface_dbus_server_restore_focused_window (self=self@entry=0x603def19b0f0 [WingpanelInterfaceDBusServer], error=error@entry=0x7fff12cde7b8)
    at wingpanel-interface/libwingpanel-interface.so.p/DBusServer.c:221
#3  0x000075828848a46b in _dbus_wingpanel_interface_dbus_server_restore_focused_window
    (self=0x603def19b0f0 [WingpanelInterfaceDBusServer], _parameters_=<optimized out>, invocation=0x75827402ae10 [GDBusMethodInvocation])
    at wingpanel-interface/libwingpanel-interface.so.p/DBusServer.c:437
#4  0x00007582925f8be8 in call_in_idle_cb (user_data=0x75827402ae10) at ../../../gio/gdbusconnection.c:5453
#5  0x000075829277b48e in g_main_dispatch (context=0x603deeddfff0) at ../../../glib/gmain.c:3344
#6  0x00007582927da717 in g_main_context_dispatch_unlocked (context=0x603deeddfff0) at ../../../glib/gmain.c:4152
#7  g_main_context_iterate_unlocked.isra.0 (context=0x603deeddfff0, block=block@entry=1, dispatch=dispatch@entry=1, self=<optimized out>) at ../../../glib/gmain.c:4217
#8  0x000075829277bf77 in g_main_loop_run (loop=0x603def132410) at ../../../glib/gmain.c:4419
#9  0x00007582916d4d0a in meta_context_run_main_loop (context=<optimized out>, error=error@entry=0x7fff12cdead8) at ../src/core/meta-context.c:523
#10 0x0000603ded3c0318 in gala_main (args=<optimized out>, args_length1=<optimized out>) at src/gala.p/Main.c:302
#11 0x000075829102a1ca in __libc_start_call_main (main=main@entry=0x603ded3ab1d0 <main>, argc=argc@entry=1, argv=argv@entry=0x7fff12cdef38) at ../sysdeps/nptl/libc_start_call_main.h:58
#12 0x000075829102a28b in __libc_start_main_impl
    (main=0x603ded3ab1d0 <main>, argc=1, argv=0x7fff12cdef38, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7fff12cdef28) at ../csu/libc-start.c:360
#13 0x0000603ded3ab205 in _start ()
```