### PR TITLE
Control: runtime depends on Gala 8

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,8 @@ Homepage: https://github.com/elementary/wingpanel
 
 Package: io.elementary.wingpanel
 Architecture: any
-Depends: libwingpanel3 (= ${binary:Version}),
+Depends: gala (>= 8.0.0),
+         libwingpanel3 (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}
 Replaces: wingpanel (<< 2.3.2)


### PR DESCRIPTION
Runtime depends on Gala for positioning, background, etc.

Presumably version 8 since we're not building Gala in daily for OS 7 anymore: https://code.launchpad.net/~elementary-os/+recipe/gala-daily