### PR TITLE
Application: don't hardcode theme

### DIFF
--- a/data/wingpanel.metainfo.xml.in
+++ b/data/wingpanel.metainfo.xml.in
@@ -46,6 +46,7 @@
       <issues>
         <issue url="https://github.com/elementary/wingpanel/issues/408">Wingpanel has top gap when apps are snapped to left-half/right-half</issue>
         <issue url="https://github.com/elementary/wingpanel/issues/515">wayland: Opening multitasking view breaks gala</issue>
+        <issue url="https://github.com/elementary/wingpanel/issues/530">does not follow accent color in X session</issue>
       </issues>
     </release>
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -87,10 +87,6 @@ public class Wingpanel.Application : Gtk.Application {
             var gtk_settings = Gtk.Settings.get_default ();
             gtk_settings.gtk_icon_theme_name = "elementary";
 
-            if (!gtk_settings.gtk_theme_name.has_prefix ("io.elementary")) {
-                gtk_settings.gtk_theme_name = "io.elementary.stylesheet.blueberry";
-            }
-
             gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == DARK;
 
             granite_settings.notify["prefers-color-scheme"].connect (() => {


### PR DESCRIPTION
Fixes #530 

This was previously done because we were depending on our stylesheet for panel styles. Styles live here now and there's some issues in some indicators with Adwaita still, but for the most part things are general fine :shrug: 