### PR TITLE
metainfo: Fix typo 'scoll' -> 'scroll'

### DIFF
--- a/data/wingpanel.metainfo.xml.in
+++ b/data/wingpanel.metainfo.xml.in
@@ -82,7 +82,7 @@
         <p>Improvements:</p>
         <ul>
           <li>Fallback to maximized style if window manager is unavailable</li>
-          <li>Listen to smooth scoll events</li>
+          <li>Listen to smooth scroll events</li>
           <li>Updated translations</li>
         </ul>
       </description>


### PR DESCRIPTION
From [ihor_ck's comment](https://l10n.elementary.io/translate/wingpanel/wingpanel-extra/en/?q=has:comment#comments) on Weblate:

> Typo: scoll -> scroll

This typo is in the release note of a previous release; feel free to close if we shouldn't edit release notes that already published.