### PR TITLE
Reset indicator selection when popover is closed

### DIFF
--- a/src/Services/PopoverManager.vala
+++ b/src/Services/PopoverManager.vala
@@ -86,6 +86,7 @@ public class Wingpanel.Services.PopoverManager : Object {
         });
 
         popover.closed.connect (() => {
+            current_indicator = null;
             make_modal (popover, false);
         });
         popover.unmap.connect (() => {


### PR DESCRIPTION
Fixes https://github.com/elementary/wingpanel/issues/519