### PR TITLE
Snappier "top panel workspace scroll"

### DIFF
--- a/src/Widgets/Panel.vala
+++ b/src/Widgets/Panel.vala
@@ -98,7 +98,7 @@ public class Wingpanel.Widgets.Panel : Gtk.EventBox {
 
             current_scroll_delta += dx + dy;
 
-            if (current_scroll_delta.abs () > 3) { //TODO: Check whether 10 is good here.
+            if (current_scroll_delta.abs () > 2) { //TODO: Check whether 10 is good here.
                 current_scroll_delta = 0;
             }
         });

--- a/src/Widgets/Panel.vala
+++ b/src/Widgets/Panel.vala
@@ -98,7 +98,7 @@ public class Wingpanel.Widgets.Panel : Gtk.EventBox {
 
             current_scroll_delta += dx + dy;
 
-            if (current_scroll_delta.abs () > 10) { //TODO: Check whether 10 is good here.
+            if (current_scroll_delta.abs () > 1) { //TODO: Check whether 10 is good here.
                 current_scroll_delta = 0;
             }
         });

--- a/src/Widgets/Panel.vala
+++ b/src/Widgets/Panel.vala
@@ -98,7 +98,7 @@ public class Wingpanel.Widgets.Panel : Gtk.EventBox {
 
             current_scroll_delta += dx + dy;
 
-            if (current_scroll_delta.abs () > 2) { //TODO: Check whether 10 is good here.
+            if (current_scroll_delta.abs () > 3) { //TODO: Check whether 10 is good here.
                 current_scroll_delta = 0;
             }
         });

--- a/src/Widgets/Panel.vala
+++ b/src/Widgets/Panel.vala
@@ -98,7 +98,7 @@ public class Wingpanel.Widgets.Panel : Gtk.EventBox {
 
             current_scroll_delta += dx + dy;
 
-            if (current_scroll_delta.abs () > 1) { //TODO: Check whether 10 is good here.
+            if (current_scroll_delta.abs () > 2) { //TODO: Check whether 10 is good here.
                 current_scroll_delta = 0;
             }
         });

--- a/src/Widgets/Panel.vala
+++ b/src/Widgets/Panel.vala
@@ -98,7 +98,7 @@ public class Wingpanel.Widgets.Panel : Gtk.EventBox {
 
             current_scroll_delta += dx + dy;
 
-            if (current_scroll_delta.abs () > 2) { //TODO: Check whether 10 is good here.
+            if (current_scroll_delta.abs () > 1) { // Balance between reactive and ignoring misinput
                 current_scroll_delta = 0;
             }
         });


### PR DESCRIPTION
elementary's default implementation felt very heavy - you have to scroll a lot before it picks up anything, and the experience of going immediately a few workspaces left or right feels frustrating
The icon is too slow and keyboard not always in reach, so i use that feature daily.

"1" and "2" allows for a few misinputs (such as when mousewheel is between two notches somehow), but also picks up quickly enough user intent to react and switch
From using it a few days, ive set on "1" as "2" sometimes ignored valid inputs still. (roughly on my mouse thats the amount of notches that can be scrolled without causing a switch- I am not sure if other mouses would be different)

you cannot "scroll" too hard and go more than one workspace because the panel ignores further scrolling until the new workspace is fully shown. So low value is not an issue like it can be in another interpretations ive used, where you scroll a little too hard and end up too far in the workspace "stream" - Here you still end up scrolling one after the other

EDIT: Eventual refinements:
if the workspace switch isnt triggered by a scroll, the panel seems to "remember" the misinput and not accept any future one until it switches again

https://github.com/elementary/wingpanel/issues/588