### PR TITLE
ISSUE-594 fix panel actual_height with scale factor

### DIFF
--- a/src/PanelWindow.vala
+++ b/src/PanelWindow.vala
@@ -159,7 +159,7 @@ public class Wingpanel.PanelWindow : Gtk.Window {
     }
 
     private int get_actual_height () {
-        if (!Services.DisplayConfig.is_logical_layout () || Gdk.Display.get_default () is Gdk.Wayland.Display) {
+        if (!Services.DisplayConfig.is_logical_layout ()) {
             return get_allocated_height () * get_scale_factor ();
         }
 

--- a/src/PanelWindow.vala
+++ b/src/PanelWindow.vala
@@ -159,7 +159,7 @@ public class Wingpanel.PanelWindow : Gtk.Window {
     }
 
     private int get_actual_height () {
-        if (!Services.DisplayConfig.is_logical_layout () && Gdk.Display.get_default () is Gdk.Wayland.Display) {
+        if (!Services.DisplayConfig.is_logical_layout () || Gdk.Display.get_default () is Gdk.Wayland.Display) {
             return get_allocated_height () * get_scale_factor ();
         }
 


### PR DESCRIPTION
Changed condition to define right actual panel height with scale factor to prevent the overlay panel to other window in full mode.

Fixes #594