### PR TITLE
Fix indicator not opening when the translucent style is active

### DIFF
--- a/data/styles/Application.css
+++ b/data/styles/Application.css
@@ -16,7 +16,6 @@ panel.maximized {
 
 panel.translucent > box {
     border-radius: 5px 5px 0 0;
-    margin-bottom: 4px;
 }
 
 panel.translucent.color-dark > box {

--- a/src/PanelWindow.vala
+++ b/src/PanelWindow.vala
@@ -72,10 +72,18 @@ public class Wingpanel.PanelWindow : Gtk.Window {
     }
 
     private void on_realize () {
+        ((Gdk.Toplevel) get_surface ()).compute_size.connect (on_compute_size);
+
         update_panel_dimensions ();
         Services.BackgroundManager.initialize (panel_height);
 
         init_wl ();
+    }
+
+    private void on_compute_size (Gdk.ToplevelSize top_level_size) {
+        /* We do our own size calculation to make sure the box shadow in the translucent style isn't cut off */
+        top_level_size.set_size (width_request, panel.get_height () + 5);
+        top_level_size.set_shadow_width (0, 0, 0, 5);
     }
 
     private void update_panel_dimensions () {


### PR DESCRIPTION
Currently indicator can't be opened when the panel is in the translucent style. This fixes that.
I don't really know why this breaks it but I also don't seem to see any difference without this so I decided to just remove it.