### PR TITLE
control: Use Granite 9

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Build-Depends:
     libgee-0.8-dev,
     libgirepository1.0-dev,
     libglib2.0-dev (>= 2.32),
-    libgranite-7-dev,
+    libgranite-9-dev,
     libgtk-4-dev,
     libsoup-3.0-dev,
     meson,


### PR DESCRIPTION
Followup #682

I confirmed I can build #682 with the following commands:

```
$ docker run --rm -it ghcr.io/elementary/docker:development-target bash

(inside docker)
# git clone https://github.com/elementary/wingpanel.git
# cd wingpanel/
# git checkout danirabbit/granite-9
# git checkout origin/ryonakano/deb-packaging-granite-9 -- debian
# apt build-dep .
# meson setup builddir --prefix=/usr
# meson compile -C builddir
```