### PR TITLE
BackgroundManager: Defer to user preference when translucent

### DIFF
--- a/data/styles/Application.css
+++ b/data/styles/Application.css
@@ -26,7 +26,7 @@ panel.translucent.color-dark > box {
 }
 
 panel.translucent.color-light > box {
-    background-color: alpha(white, 0.3);
+    background-color: alpha(white, 0.5);
     box-shadow:
         inset 0 -1px 0 0 alpha(white, 0.15),
         inset 0 1px 0 0 alpha(white, 0.15),

--- a/src/PanelWindow.vala
+++ b/src/PanelWindow.vala
@@ -21,7 +21,6 @@ public class Wingpanel.PanelWindow : Gtk.Window {
     public Services.PopoverManager popover_manager;
 
     private Widgets.Panel panel;
-    private int panel_height;
 
     private Pantheon.Desktop.Shell? desktop_shell;
     private Pantheon.Desktop.Panel? desktop_panel;
@@ -75,7 +74,7 @@ public class Wingpanel.PanelWindow : Gtk.Window {
         ((Gdk.Toplevel) get_surface ()).compute_size.connect (on_compute_size);
 
         update_panel_dimensions ();
-        Services.BackgroundManager.initialize (panel_height);
+        Services.BackgroundManager.initialize (panel.get_height ().clamp (16, 48));
 
         init_wl ();
     }
@@ -87,8 +86,6 @@ public class Wingpanel.PanelWindow : Gtk.Window {
     }
 
     private void update_panel_dimensions () {
-        panel_height = panel.get_height ();
-
         // We just use our monitor because Gala makes sure we are always on the primary one
         var monitor_dimensions = get_display ().get_monitor_at_surface (get_surface ()).get_geometry ();
 

--- a/src/Services/BackgroundManager.vala
+++ b/src/Services/BackgroundManager.vala
@@ -132,20 +132,20 @@ namespace Wingpanel.Services {
 
             bus.state_changed.connect ((state, animation_duration) => {
                 current_state = state;
-                state_updated (state, animation_duration);
+                state_updated (animation_duration);
             });
 
             state_updated ();
             return true;
         }
 
-        private void state_updated (BackgroundState state = current_state, uint animation_duration = 0) {
+        private void state_updated (uint animation_duration = 0) {
             if (!use_transparency) {
                 background_state_changed (BackgroundState.MAXIMIZED, animation_duration);
                 return;
             }
 
-            switch (state) {
+            switch (current_state) {
                 case TRANSLUCENT_DARK:
                 case TRANSLUCENT_LIGHT:
                     // Prefer user preference: https://github.com/elementary/wingpanel/issues/657
@@ -159,7 +159,7 @@ namespace Wingpanel.Services {
                     break;
             }
 
-            background_state_changed (state, animation_duration);
+            background_state_changed (current_state, animation_duration);
         }
 
         public static BackgroundManager get_default () {

--- a/src/Services/BackgroundManager.vala
+++ b/src/Services/BackgroundManager.vala
@@ -43,8 +43,6 @@ namespace Wingpanel.Services {
         private static BackgroundManager? instance = null;
 
         private InterfaceBus? bus = null;
-
-        private BackgroundState current_state = BackgroundState.LIGHT;
         private bool use_transparency = true;
 
         private bool bus_available {
@@ -64,6 +62,8 @@ namespace Wingpanel.Services {
 
         private BackgroundManager () {
             var panel_settings = new GLib.Settings ("io.elementary.desktop.wingpanel");
+
+            Granite.StyleManager.get_default ().notify["color-scheme"].connect (() => state_updated ());
 
             panel_settings.changed["use-transparency"].connect (() => {
                 use_transparency = panel_settings.get_boolean ("use-transparency");
@@ -126,16 +126,38 @@ namespace Wingpanel.Services {
             }
 
             bus.state_changed.connect ((state, animation_duration) => {
-                current_state = state;
-                state_updated (animation_duration);
+                state_updated (state, animation_duration);
             });
 
             state_updated ();
             return true;
         }
 
-        private void state_updated (uint animation_duration = 0) {
-            background_state_changed (use_transparency ? current_state : BackgroundState.MAXIMIZED, animation_duration);
+        private void state_updated (BackgroundState state = MAXIMIZED, uint animation_duration = 0) {
+            if (!use_transparency) {
+                background_state_changed (BackgroundState.MAXIMIZED, animation_duration);
+                return;
+            }
+
+            switch (state) {
+                case TRANSLUCENT_DARK:
+                case TRANSLUCENT_LIGHT:
+                    // Prefer user preference: https://github.com/elementary/wingpanel/issues/657
+                    switch (Granite.StyleManager.get_default ().color_scheme) {
+                        case NO_PREFERENCE:
+                        case LIGHT:
+                            background_state_changed (TRANSLUCENT_LIGHT, animation_duration);
+                            break;
+                        case DARK:
+                            background_state_changed (TRANSLUCENT_DARK, animation_duration);
+                            break;
+                    }
+                    return;
+                default:
+                    break;
+            }
+
+            background_state_changed (state, animation_duration);
         }
 
         public static BackgroundManager get_default () {

--- a/src/Services/BackgroundManager.vala
+++ b/src/Services/BackgroundManager.vala
@@ -54,7 +54,7 @@ namespace Wingpanel.Services {
             }
         }
 
-        private Gtk.Settings style_manager;
+        private Gtk.Settings gtk_settings;
         private int panel_height;
 
         public signal void background_state_changed (BackgroundState state, uint animation_duration);
@@ -68,8 +68,8 @@ namespace Wingpanel.Services {
         private BackgroundManager () {
             var panel_settings = new GLib.Settings ("io.elementary.desktop.wingpanel");
 
-            style_manager = Gtk.Settings.get_default ();
-            style_manager.notify["gtk-application-prefer-dark-theme"].connect (() => state_updated ());
+            gtk_settings = Gtk.Settings.get_default ();
+            gtk_settings.notify["gtk-application-prefer-dark-theme"].connect (() => state_updated ());
 
             panel_settings.changed["use-transparency"].connect (() => {
                 use_transparency = panel_settings.get_boolean ("use-transparency");
@@ -148,7 +148,7 @@ namespace Wingpanel.Services {
                     case DARK:
                     case LIGHT:
                         // Prefer user preference: https://github.com/elementary/wingpanel/issues/657
-                        if (style_manager.gtk_application_prefer_dark_theme) {
+                        if (gtk_settings.gtk_application_prefer_dark_theme) {
                             background_state_changed (TRANSLUCENT_LIGHT, animation_duration);
                         } else {
                             background_state_changed (TRANSLUCENT_DARK, animation_duration);
@@ -166,7 +166,7 @@ namespace Wingpanel.Services {
                 case TRANSLUCENT_DARK:
                 case TRANSLUCENT_LIGHT:
                     // Prefer user preference: https://github.com/elementary/wingpanel/issues/657
-                    if (style_manager.gtk_application_prefer_dark_theme) {
+                    if (gtk_settings.gtk_application_prefer_dark_theme) {
                         background_state_changed (TRANSLUCENT_LIGHT, animation_duration);
                     } else {
                         background_state_changed (TRANSLUCENT_DARK, animation_duration);

--- a/src/Services/BackgroundManager.vala
+++ b/src/Services/BackgroundManager.vala
@@ -43,6 +43,8 @@ namespace Wingpanel.Services {
         private static BackgroundManager? instance = null;
 
         private InterfaceBus? bus = null;
+        // Latest state as sent from Gala
+        private BackgroundState current_state = BackgroundState.LIGHT;
         private bool use_transparency = true;
 
         private bool bus_available {
@@ -51,6 +53,7 @@ namespace Wingpanel.Services {
             }
         }
 
+        private Gtk.Settings style_manager;
         private int panel_height;
 
         public signal void background_state_changed (BackgroundState state, uint animation_duration);
@@ -63,7 +66,8 @@ namespace Wingpanel.Services {
         private BackgroundManager () {
             var panel_settings = new GLib.Settings ("io.elementary.desktop.wingpanel");
 
-            Granite.StyleManager.get_default ().notify["color-scheme"].connect (() => state_updated ());
+            style_manager = Gtk.Settings.get_default ();
+            style_manager.notify["gtk-application-prefer-dark-theme"].connect (() => state_updated ());
 
             panel_settings.changed["use-transparency"].connect (() => {
                 use_transparency = panel_settings.get_boolean ("use-transparency");
@@ -126,6 +130,7 @@ namespace Wingpanel.Services {
             }
 
             bus.state_changed.connect ((state, animation_duration) => {
+                current_state = state;
                 state_updated (state, animation_duration);
             });
 
@@ -133,7 +138,7 @@ namespace Wingpanel.Services {
             return true;
         }
 
-        private void state_updated (BackgroundState state = MAXIMIZED, uint animation_duration = 0) {
+        private void state_updated (BackgroundState state = current_state, uint animation_duration = 0) {
             if (!use_transparency) {
                 background_state_changed (BackgroundState.MAXIMIZED, animation_duration);
                 return;
@@ -143,14 +148,10 @@ namespace Wingpanel.Services {
                 case TRANSLUCENT_DARK:
                 case TRANSLUCENT_LIGHT:
                     // Prefer user preference: https://github.com/elementary/wingpanel/issues/657
-                    switch (Granite.StyleManager.get_default ().color_scheme) {
-                        case NO_PREFERENCE:
-                        case LIGHT:
-                            background_state_changed (TRANSLUCENT_LIGHT, animation_duration);
-                            break;
-                        case DARK:
-                            background_state_changed (TRANSLUCENT_DARK, animation_duration);
-                            break;
+                    if (style_manager.gtk_application_prefer_dark_theme) {
+                        background_state_changed (TRANSLUCENT_LIGHT, animation_duration);
+                    } else {
+                        background_state_changed (TRANSLUCENT_DARK, animation_duration);
                     }
                     return;
                 default:

--- a/src/Services/BackgroundManager.vala
+++ b/src/Services/BackgroundManager.vala
@@ -141,7 +141,21 @@ namespace Wingpanel.Services {
 
         private void state_updated (uint animation_duration = Granite.TRANSITION_DURATION_IN_PLACE) {
             if (!use_transparency) {
-                background_state_changed (BackgroundState.MAXIMIZED, animation_duration);
+                switch (current_state) {
+                    case DARK:
+                    case LIGHT:
+                        // Prefer user preference: https://github.com/elementary/wingpanel/issues/657
+                        if (style_manager.gtk_application_prefer_dark_theme) {
+                            background_state_changed (TRANSLUCENT_LIGHT, animation_duration);
+                        } else {
+                            background_state_changed (TRANSLUCENT_DARK, animation_duration);
+                        }
+                        return;
+                    default:
+                        background_state_changed (BackgroundState.MAXIMIZED, animation_duration);
+                        break;
+                }
+
                 return;
             }
 

--- a/src/Services/BackgroundManager.vala
+++ b/src/Services/BackgroundManager.vala
@@ -54,7 +54,6 @@ namespace Wingpanel.Services {
             }
         }
 
-        private Gtk.Settings gtk_settings;
         private int panel_height;
 
         public signal void background_state_changed (BackgroundState state, uint animation_duration);
@@ -68,8 +67,7 @@ namespace Wingpanel.Services {
         private BackgroundManager () {
             var panel_settings = new GLib.Settings ("io.elementary.desktop.wingpanel");
 
-            gtk_settings = Gtk.Settings.get_default ();
-            gtk_settings.notify["gtk-application-prefer-dark-theme"].connect (() => state_updated ());
+            Gtk.Settings.get_default ().notify["gtk-application-prefer-dark-theme"].connect (() => state_updated ());
 
             panel_settings.changed["use-transparency"].connect (() => {
                 use_transparency = panel_settings.get_boolean ("use-transparency");
@@ -152,7 +150,7 @@ namespace Wingpanel.Services {
                 case TRANSLUCENT_DARK:
                 case TRANSLUCENT_LIGHT:
                     // Prefer user preference: https://github.com/elementary/wingpanel/issues/657
-                    if (gtk_settings.gtk_application_prefer_dark_theme) {
+                    if (Gtk.Settings.get_default ().gtk_application_prefer_dark_theme) {
                         background_state_changed (TRANSLUCENT_LIGHT, animation_duration);
                     } else {
                         background_state_changed (TRANSLUCENT_DARK, animation_duration);

--- a/src/Services/BackgroundManager.vala
+++ b/src/Services/BackgroundManager.vala
@@ -144,21 +144,7 @@ namespace Wingpanel.Services {
 
         private void state_updated (uint animation_duration = Granite.TRANSITION_DURATION_IN_PLACE) {
             if (!use_transparency) {
-                switch (current_state) {
-                    case DARK:
-                    case LIGHT:
-                        // Prefer user preference: https://github.com/elementary/wingpanel/issues/657
-                        if (gtk_settings.gtk_application_prefer_dark_theme) {
-                            background_state_changed (TRANSLUCENT_LIGHT, animation_duration);
-                        } else {
-                            background_state_changed (TRANSLUCENT_DARK, animation_duration);
-                        }
-                        return;
-                    default:
-                        background_state_changed (BackgroundState.MAXIMIZED, animation_duration);
-                        break;
-                }
-
+                background_state_changed (BackgroundState.MAXIMIZED, animation_duration);
                 return;
             }
 

--- a/src/Services/BackgroundManager.vala
+++ b/src/Services/BackgroundManager.vala
@@ -43,6 +43,7 @@ namespace Wingpanel.Services {
         private static BackgroundManager? instance = null;
 
         private InterfaceBus? bus = null;
+
         // Latest state as sent from Gala
         private BackgroundState current_state = BackgroundState.LIGHT;
         private bool use_transparency = true;

--- a/src/Services/BackgroundManager.vala
+++ b/src/Services/BackgroundManager.vala
@@ -139,7 +139,7 @@ namespace Wingpanel.Services {
             return true;
         }
 
-        private void state_updated (uint animation_duration = 0) {
+        private void state_updated (uint animation_duration = Granite.TRANSITION_DURATION_IN_PLACE) {
             if (!use_transparency) {
                 background_state_changed (BackgroundState.MAXIMIZED, animation_duration);
                 return;


### PR DESCRIPTION
fixes #657

Follow the user preference when the panel will be translucent.

<img width="2560" height="1440" alt="Screenshot from 2026-08-27 17 41 01" src="https://github.com/user-attachments/assets/1235c6da-fea2-4fbf-a31e-59bba2899e50" />
<img width="2560" height="1440" alt="Screenshot from 2026-08-27 17 41 29" src="https://github.com/user-attachments/assets/e6e5c9d1-e7f1-4956-b103-c9fe17ca966e" />

If Gala thinks the panel should be transparent, reduce transparency makes it translucent:

<img width="2560" height="1440" alt="Screenshot from 2026-08-27 17 45 30" src="https://github.com/user-attachments/assets/547e9777-0901-4ed7-b2ec-efae811b8c23" />
<img width="2560" height="1440" alt="Screenshot from 2026-08-27 17 45 42" src="https://github.com/user-attachments/assets/6843dcbf-4374-48cb-8c25-290df9f063c3" />

if Gala thinks the panel should be translucent, reduce transparency makes it completely opaque

<img width="2560" height="1440" alt="Screenshot from 2026-08-27 17 40 13" src="https://github.com/user-attachments/assets/75c7cc43-7fb4-44a2-b130-b1bcd8bdb436" />

<img width="2560" height="1440" alt="Screenshot from 2026-08-27 17 41 14" src="https://github.com/user-attachments/assets/ec2552fe-6b6a-48a4-baa4-aab15e0e45d9" />

If Gala thinks the panel should be transparent, maintain the current behavior:

<img width="2560" height="1440" alt="Screenshot from 2026-08-27 17 41 54" src="https://github.com/user-attachments/assets/9608ae71-c0e1-4d48-ae98-87b1fed89e8a" />
<img width="2560" height="1440" alt="Screenshot from 2026-08-27 17 42 06" src="https://github.com/user-attachments/assets/559c78f0-27dd-4a93-a2b7-58c750578332" />

Note: This should theoretically use Granite.StyleManager, but it's not sending correct color info rn

