### PR TITLE
Handle indicator cycling via Gtk.ShortcutController

### DIFF
--- a/src/PanelWindow.vala
+++ b/src/PanelWindow.vala
@@ -55,17 +55,6 @@ public class Wingpanel.PanelWindow : Gtk.Window {
         child = box;
         remove_css_class (Granite.STYLE_CLASS_BACKGROUND);
 
-        var cycle_action = new SimpleAction ("cycle", null);
-        cycle_action.activate.connect (() => panel.cycle (true));
-
-        var cycle_back_action = new SimpleAction ("cycle-back", null);
-        cycle_back_action.activate.connect (() => panel.cycle (false));
-
-        application.add_action (cycle_action);
-        application.add_action (cycle_back_action);
-        application.set_accels_for_action ("app.cycle", {"<Control>Tab"});
-        application.set_accels_for_action ("app.cycle-back", {"<Control><Shift>Tab"});
-
         popover_manager.notify["indicator-open"].connect (() => {
             if (!popover_manager.indicator_open) {
                 Services.BackgroundManager.get_default ().restore_window ();

--- a/src/Widgets/Panel.vala
+++ b/src/Widgets/Panel.vala
@@ -97,6 +97,36 @@ public class Wingpanel.Widgets.Panel : Granite.Bin {
                 current_scroll_delta = 0;
             }
         });
+
+        var cycle_action = new SimpleAction ("cycle", null);
+        cycle_action.activate.connect (() => cycle (true));
+
+        var cycle_back_action = new SimpleAction ("cycle-back", null);
+        cycle_back_action.activate.connect (() => cycle (false));
+
+        var action_group = new SimpleActionGroup ();
+        action_group.add_action (cycle_action);
+        action_group.add_action (cycle_back_action);
+
+        insert_action_group ("panel", action_group);
+
+        var cycle_shortcut = new Gtk.Shortcut (
+            new Gtk.KeyvalTrigger (Gdk.Key.Tab, CONTROL_MASK),
+            new Gtk.NamedAction ("panel.cycle")
+        );
+        var cycle_back_shortcut = new Gtk.Shortcut (
+            new Gtk.KeyvalTrigger (Gdk.Key.Tab, CONTROL_MASK | SHIFT_MASK),
+            new Gtk.NamedAction ("panel.cycle-back")
+        );
+
+        var shortcut_controller = new Gtk.ShortcutController () {
+            propagation_phase = CAPTURE,
+            propagation_limit = NONE // we need to listen to popover events
+        };
+        shortcut_controller.add_shortcut (cycle_shortcut);
+        shortcut_controller.add_shortcut (cycle_back_shortcut);
+
+        add_controller (shortcut_controller);
     }
 
     private void begin_drag (double x, double y) {
@@ -106,7 +136,7 @@ public class Wingpanel.Widgets.Panel : Granite.Bin {
         background_manager.begin_grab_focused_window ((int) x, (int) y);
     }
 
-    public void cycle (bool forward) {
+    private void cycle (bool forward) {
         var current = popover_manager.current_indicator;
         if (current == null) {
             return;


### PR DESCRIPTION
Addresses https://github.com/elementary/wingpanel/issues/710

Still very broken, but at least it tries to cycle through indicators. Applications Menu and Sound Indicator still block shortcuts... Not sure why

We can't use Application.set_accels_for_action () because it also uses Gtk.ShortcutController, but without propagation_limit = NONE. And since Gtk4 port the popovers are separate surfaces, the panel window can't get events from popover windows.