### PR TITLE
Move ServerType enum to its own file

### DIFF
--- a/lib/IndicatorManager.vala
+++ b/lib/IndicatorManager.vala
@@ -29,29 +29,6 @@ public class Wingpanel.IndicatorManager : GLib.Object {
     }
 
     /**
-     * The type of the server displaying the indicator.
-     */
-    public enum ServerType {
-        SESSION,
-        GREETER;
-
-        public string restrictions_file_name () {
-            switch (this) {
-                case SESSION :
-
-                    return "default";
-
-                case GREETER:
-
-                    return "greeter";
-
-                default:
-                    assert_not_reached ();
-            }
-        }
-    }
-
-    /**
      * Called when a new indicator was added.
      */
     public signal void indicator_added (Wingpanel.Indicator indicator);

--- a/lib/ServerType.vala
+++ b/lib/ServerType.vala
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ * SPDX-FileCopyrightText: 2026 elementary, Inc. (https://elementary.io)
+ */
+
+/**
+ * The type of the server displaying the indicator.
+ */
+public enum Wingpanel.ServerType {
+    SESSION,
+    GREETER;
+}

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -26,6 +26,7 @@ libwingpanel_lib = library(
     'IndicatorManager.vala',
     'KeybindingHelper.vala',
     'PopoverMenuItem.vala',
+    'ServerType.vala',
     config_header,
     dependencies: [libwingpanel_deps, config_vapi],
     vala_header: 'wingpanel-9.h',

--- a/sample/SampleIndicator.vala
+++ b/sample/SampleIndicator.vala
@@ -110,12 +110,12 @@ public class Sample.Indicator : Wingpanel.Indicator {
  * This method is called once after your plugin has been loaded.
  * Create and return your indicator here if it should be displayed on the current server.
  */
-public Wingpanel.Indicator? get_indicator (Module module, Wingpanel.IndicatorManager.ServerType server_type) {
+public Wingpanel.Indicator? get_indicator (Module module, Wingpanel.ServerType server_type) {
     /* A small message for debugging reasons */
     debug ("Activating Sample Indicator");
 
     /* Check which server has loaded the plugin */
-    if (server_type != Wingpanel.IndicatorManager.ServerType.SESSION) {
+    if (server_type != Wingpanel.ServerType.SESSION) {
         /* We want to display our sample indicator only in the "normal" session, not on the login screen, so stop here! */
         return null;
     }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -40,9 +40,9 @@ public class Wingpanel.Application : Gtk.Application {
         VariantDict options = command_line.get_options_dict ();
 
         if (options.contains (SERVER_TYPE_ACTION_NAME)) {
-            IndicatorManager.get_default ().initialize (IndicatorManager.ServerType.GREETER);
+            IndicatorManager.get_default ().initialize (ServerType.GREETER);
         } else {
-            IndicatorManager.get_default ().initialize (IndicatorManager.ServerType.SESSION);
+            IndicatorManager.get_default ().initialize (ServerType.SESSION);
         }
 
         if (options.contains (TOGGLE_INDICATOR_ACTION_NAME)) {


### PR DESCRIPTION
Breaks API compatibility. So all indicators have to be recompiled after this branch. This step is needed for https://github.com/elementary/wingpanel/pull/722 and right now is the best time to do it